### PR TITLE
Add initial spec based on explainer

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1,0 +1,265 @@
+<pre class='metadata'>
+Title: Picture In Picture
+Shortname: picture-in-picture
+Level: 1
+Status: ED
+ED: https://wicg.github.io/picture-in-picture
+Group: WICG
+Editor: François Beaufort, Google, fbeaufort@google.com
+Editor: Mounir Lamouri, Google, mlamouri@google.com
+Abstract: This specification intends to provide APIs to allow websites to
+Abstract: create a floating video window over the desktop.
+</pre>
+
+# Introduction # {#intro}
+
+<em>This section is non-normative.</em>
+
+Many users want to continue consuming media while they interact with other
+content, sites, or applications on their device. A common UI affordance for
+this type of activity is Picture in Picture, where the video is contained in a
+separate miniature window that is viewable above all other activities. Most
+desktop and mobile OSs have announced or released platform-level support for
+Picture In Picture, as have many browsers.
+
+This specification aims to allow websites to initiate and control this behavior
+by exposing the following sets of properties to the API:
+
+* Notify the website when it enters and leave Picture in Picture mode.
+* Allow the website to trigger Picture in Picture via a user gesture on a video element.
+* Allow the website to exit Picture in Picture.
+* Allow the website to check if Picture in Picture can be triggered.
+* Take a hint for the preferred window size and position which could be ignored by the user agent.
+
+# API # {#api}
+
+The proposed Picture In Picture API is very similar to the <a>Fullscreen
+API</a> as they have similar properties. The API only applies on
+<a><code>HTMLVideoElement</code></a> at the moment but is meant to be
+extensible.
+
+## Example ## {#example}
+
+```html
+<video id="video" src="https://example.com/video.mp4"></video>
+<button id="pipButton"></button>
+
+<script>
+  pipButton.hidden = !document.pictureInPictureEnabled;
+
+  pipButton.addEventListener('click', function() {
+    if (!document.pictureInPictureElement) {
+      video.requestPictureInPicture().catch(error => {
+        // Video failed to enter Picture In Picture mode.
+      });
+    } else {
+      document.exitPictureInPicture().catch(error => {
+        // Video failed to leave Picture In Picture mode.
+      });
+    }
+  });
+
+  video.addEventListener('enterpictureinpicture', function() {
+    // Video entered Picture In Picture mode.
+  });
+
+  video.addEventListener('leavepictureinpicture', function() {
+    // Video left Picture In Picture mode.
+  });
+</script>
+```
+
+## <code>HTMLVideoElement</code> extension ## {#htmlvideoelement-extension}
+
+<pre class="idl">
+  dictionary PictureInPictureOptions {
+    unsigned long width;
+    unsigned long height;
+    unsigned long top;
+    unsigned long start;
+  };
+</pre>
+
+<pre class="idl">
+  partial interface HTMLVideoElement {
+    Promise&lt;void> requestPictureInPicture(optional PictureInPictureOptions options);
+
+    attribute EventHandler onenterpictureinpicture;
+    attribute EventHandler onleavepictureinpicture;
+  };
+</pre>
+
+The {{requestPictureInPicture()}} method, when invoked, MUST
+return <a>a new promise</a> |promise| and run the following steps <a>in
+parallel</a>:
+
+1. If {{pictureInPictureEnabled}} is |false|, reject |promise| with a
+{{NotSupportedError}} and abort these steps.
+2. If |options| is not valid, reject |promise| with a {{TypeError}} and abort
+these steps.
+3. Let |video| be the requested video.
+4. Run the <a>request Picture In Picture algorithm</a> with |video| and
+|options|.
+5. If the previous step threw an exception, reject |promise| with that
+exception and abort these steps.
+6. Set {{pictureInPictureElement}} to |video|.
+7. <a>Queue a task</a> to <a>fire a simple event</a> with the name
+{{enterpictureinpicture}} at the |video|. The event MUST not
+bubble, MUST not be cancelable, and has no default action.
+8. Return |promise|.
+
+Note: When a video is played in Picture in Picture, the states should
+transition as if it was played inline. That means that the events should fire
+at the same time, calling methods should have the same behaviour, etc. However,
+the user agent might transition out of Picture in Picture when the video
+element enters a state that is considered not compatible with Picture in
+Picture.
+
+When the <dfn>request Picture In Picture algorithm</dfn> with |video|
+and |options| is invoked, the user agent MUST run the following steps:
+
+1. If the algorithm is not <a>triggered by user activation</a>, throw a
+{{SecurityError}} and abort these steps.
+2. Let |pipWindow| be the Picture In Picture window that consistently stays
+above most other windows.
+3. Let |pipVideo| be the video contained in the |pipWindow|.
+4. If a |pipWindow| is not already created, create one.
+5. If one can't be created, throw a {{UnknownError}} and abort these steps.
+6. Apply |options| {{width}}, {{height}}, {{PictureInPictureOptions/top}}, and
+{{start}} to the |pipWindow| dimensions and position. If some |options| can't
+be applied, it SHOULD apply latest ones that were successfully set if any.
+7. Render |video| frames in the |pipVideo|.
+
+Note: It is recommended that the |video| frames are not rendered in the page and
+in the |pipVideo| at the same time but if they are, they must be kept in sync.
+
+## <code>Document</code> and <code>DocumentOrShadowRoot</code> extension ## {#document-extension}
+
+<pre class="idl">
+  partial interface Document {
+    readonly attribute boolean pictureInPictureEnabled;
+
+    Promise&lt;void> exitPictureInPicture();
+  };
+</pre>
+
+<pre class="idl">
+  partial interface DocumentOrShadowRoot {
+    readonly attribute Element? pictureInPictureElement;
+  };
+</pre>
+
+The {{pictureInPictureEnabled}} attribute's getter must return
+true if the <a>context object</a> is <a>allowed to use</a> the feature
+indicated by attribute name <code>allowpictureinpicture</code> and <a>Picture
+In Picture is supported</a>, and false otherwise.
+
+<dfn>Picture In Picture is supported</dfn> if there is no
+previously-established user preference, security risk, or platform limitation.
+
+The {{exitPictureInPicture()}} method, when invoked, MUST
+return <a>a new promise</a> |promise| and run the following steps <a>in
+parallel</a>:
+
+1. If {{pictureInPictureEnabled}} is |false|, reject |promise| with a
+{{NotSupportedError}} and abort these steps.
+2. Run the <a>exit Picture In Picture algorithm</a>.
+3. If the previous step threw an exception, reject |promise| with that
+exception and abort these steps.
+4. Unset {{pictureInPictureElement}}.
+5. <a>Queue a task</a> to <a>fire a simple event</a> with the name
+{{leavepictureinpicture}} at the |video|. The event MUST not
+bubble, MUST not be cancelable, and has no default action.
+6. Return |promise|.
+
+When the <dfn>exit Picture In Picture algorithm</dfn> is invoked,
+the user agent MUST run the following steps:
+
+1. Let |pipWindow| be the current Picture In Picture window.
+2. Let |pipVideo| be the video contained in the |pipWindow|.
+3. Let |video| be the source video of |pipVideo| frames.
+4. Close |pipWindow|.
+5. If |pipWindow| can't be closed, throw a {{UnknownError}} and abort these steps.
+6. Render |pipVideo| frames in the |video|.
+
+## Event types ## {#event-types}
+
+<dl>
+  <dt><dfn event for="HTMLVideoElement"><code>enterpictureinpicture</code></dfn></dt>
+  <dd>
+    Fired on a {{HTMLVideoElement}} when it enters Picture In Picture.
+  </dd>
+  <dt><dfn event for="HTMLVideoElement"><code>leavepictureinpicture</code></dfn></dt>
+  <dd>
+    Fired on a {{HTMLVideoElement}} when it leaves Picture In Picture.
+  </dd>
+</dl>
+
+# Integration # {#integration}
+
+User agents are encouraged to implement native media Picture In Picture
+controls in terms of {{requestPictureInPicture()}} and
+{{exitPictureInPicture()}}.
+
+## Interaction with remote playback ## {#remote-playback}
+
+The <a>Remote Playback specification</a> defines a <a>local playback device</a>
+and a <a>local playback state</a>. For the purpose of Picture in Picture, the
+playback is local and regardless of whether it is played in page or in Picture
+in Picture.
+
+## One Picture in Picture window ## {#one-pip-window}
+
+Operating systems with a Picture In Picture API usually restricts Picture In
+Picture to only one window.  Whether only one window is allowed in Picture In
+Picture will be left to the implementation and the platform. However, because
+of the one Picture In Picture window limitation, the specification assumes that
+a given {{Document}} can only have one Picture In Picture window.
+
+What happens when there is a Picture In Picture request while a window is
+already in Picture In Picture will be left as an implementation details: the
+current Picture In Picture window could be closed, the Picture In Picture
+request could be rejected or even two Picture In Picture windows can be
+created. Regardless, the User Agent will have to fire the appropriate events
+in order to notify the website of the Picture In Picture status changes.
+
+## Feature Policy ## {#feature-policy}
+
+This specification defines a <a>feature</a> that controls whether
+{{pictureInPictureEnabled}} is |true| or |false|.
+
+The <a>feature name</a> for this feature is <code>"picture-in-picture"</code>.
+
+The <a>default allowlist</a> for this feature is <code>["self"]</code>.
+
+<pre class="anchors">
+spec: Feature Policy; urlPrefix: https://wicg.github.io/feature-policy/#
+    type: dfn
+        text: default allowlist
+        text: feature
+        text: feature name
+</pre>
+
+<pre class="link-defaults">
+spec:dom; type:dfn; for:NamedNodeMap; text:element
+spec:html; type:dfn; for:htmlvideoelement; text:HTMLVideoElement
+spec: html
+  type: dfn
+    text: triggered by user activation
+    text: in parallel
+    text: incumbent settings object
+    text: environment settings object
+    text: global object; for: environment settings object
+    text: initialising a new document object
+    text: inserted into a document
+    text: responsible document
+    text: run a worker
+    text: HTMLVideoElement
+    text: fire a simple event
+  type: element
+    text: link
+    text: script
+  type: idl
+    text: HTMLVideoElement
+</pre>
+

--- a/index.html
+++ b/index.html
@@ -1,0 +1,2095 @@
+<!doctype html><html lang="en">
+ <head>
+  <meta content="text/html; charset=utf-8" http-equiv="Content-Type">
+  <title>Picture In Picture</title>
+  <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport">
+<style data-fill-with="stylesheet">/******************************************************************************
+ *                   Style sheet for the W3C specifications                   *
+ *
+ * Special classes handled by this style sheet include:
+ *
+ * Indices
+ *   - .toc for the Table of Contents (<ol class="toc">)
+ *     + <span class="secno"> for the section numbers
+ *   - #toc for the Table of Contents (<nav id="toc">)
+ *   - ul.index for Indices (<a href="#ref">term</a><span>, in §N.M</span>)
+ *   - table.index for Index Tables (e.g. for properties or elements)
+ *
+ * Structural Markup
+ *   - table.data for general data tables
+ *     -> use 'scope' attribute, <colgroup>, <thead>, and <tbody> for best results !
+ *     -> use <table class='complex data'> for extra-complex tables
+ *     -> use <td class='long'> for paragraph-length cell content
+ *     -> use <td class='pre'> when manual line breaks/indentation would help readability
+ *   - dl.switch for switch statements
+ *   - ol.algorithm for algorithms (helps to visualize nesting)
+ *   - .figure and .caption (HTML4) and figure and figcaption (HTML5)
+ *     -> .sidefigure for right-floated figures
+ *   - ins/del
+ *
+ * Code
+ *   - pre and code
+ *
+ * Special Sections
+ *   - .note       for informative notes             (div, p, span, aside, details)
+ *   - .example    for informative examples          (div, p, pre, span)
+ *   - .issue      for issues                        (div, p, span)
+ *   - .assertion  for assertions                    (div, p, span)
+ *   - .advisement for loud normative statements     (div, p, strong)
+ *   - .annoying-warning for spec obsoletion notices (div, aside, details)
+ *
+ * Definition Boxes
+ *   - pre.def   for WebIDL definitions
+ *   - table.def for tables that define other entities (e.g. CSS properties)
+ *   - dl.def    for definition lists that define other entitles (e.g. HTML elements)
+ *
+ * Numbering
+ *   - .secno for section numbers in .toc and headings (<span class='secno'>3.2</span>)
+ *   - .marker for source-inserted example/figure/issue numbers (<span class='marker'>Issue 4</span>)
+ *   - ::before styled for CSS-generated issue/example/figure numbers:
+ *     -> Documents wishing to use this only need to add
+ *        figcaption::before,
+ *        .caption::before { content: "Figure "  counter(figure) " ";  }
+ *        .example::before { content: "Example " counter(example) " "; }
+ *        .issue::before   { content: "Issue "   counter(issue) " ";   }
+ *
+ * Header Stuff (ignore, just don't conflict with these classes)
+ *   - .head for the header
+ *   - .copyright for the copyright
+ *
+ * Miscellaneous
+ *   - .overlarge for things that should be as wide as possible, even if
+ *     that overflows the body text area. This can be used on an item or
+ *     on its container, depending on the effect desired.
+ *     Note that this styling basically doesn't help at all when printing,
+ *     since A4 paper isn't much wider than the max-width here.
+ *     It's better to design things to fit into a narrower measure if possible.
+ *   - js-added ToC jump links (see fixup.js)
+ *
+ ******************************************************************************/
+
+/******************************************************************************/
+/*                                   Body                                     */
+/******************************************************************************/
+
+	body {
+		counter-reset: example figure issue;
+
+		/* Layout */
+		max-width: 50em;               /* limit line length to 50em for readability   */
+		margin: 0 auto;                /* center text within page                     */
+		padding: 1.6em 1.5em 2em 50px; /* assume 16px font size for downlevel clients */
+		padding: 1.6em 1.5em 2em calc(26px + 1.5em); /* leave space for status flag     */
+
+		/* Typography */
+		line-height: 1.5;
+		font-family: sans-serif;
+		widows: 2;
+		orphans: 2;
+		word-wrap: break-word;
+		overflow-wrap: break-word;
+		hyphens: auto;
+
+		/* Colors */
+		color: black;
+		background: white top left fixed no-repeat;
+		background-size: 25px auto;
+	}
+
+
+/******************************************************************************/
+/*                         Front Matter & Navigation                          */
+/******************************************************************************/
+
+/** Header ********************************************************************/
+
+	div.head { margin-bottom: 1em }
+	div.head hr { border-style: solid; }
+
+	div.head h1 {
+		font-weight: bold;
+		margin: 0 0 .1em;
+		font-size: 220%;
+	}
+
+	div.head h2 { margin-bottom: 1.5em;}
+
+/** W3C Logo ******************************************************************/
+
+	.head .logo {
+		float: right;
+		margin: 0.4rem 0 0.2rem .4rem;
+	}
+
+	.head img[src*="logos/W3C"] {
+		display: block;
+		border: solid #1a5e9a;
+		border-width: .65rem .7rem .6rem;
+		border-radius: .4rem;
+		background: #1a5e9a;
+		color: white;
+		font-weight: bold;
+	}
+
+	.head a:hover > img[src*="logos/W3C"],
+	.head a:focus > img[src*="logos/W3C"] {
+		opacity: .8;
+	}
+
+	.head a:active > img[src*="logos/W3C"] {
+		background: #c00;
+		border-color: #c00;
+	}
+
+	/* see also additional rules in Link Styling section */
+
+/** Copyright *****************************************************************/
+
+	p.copyright,
+	p.copyright small { font-size: small }
+
+/** Back to Top / ToC Toggle **************************************************/
+
+	@media print {
+		#toc-nav {
+			display: none;
+		}
+	}
+	@media not print {
+		#toc-nav {
+			position: fixed;
+			z-index: 2;
+			bottom: 0; left: 0;
+			margin: 0;
+			min-width: 1.33em;
+			border-top-right-radius: 2rem;
+			box-shadow: 0 0 2px;
+			font-size: 1.5em;
+			color: black;
+		}
+		#toc-nav > a {
+			display: block;
+			white-space: nowrap;
+
+			height: 1.33em;
+			padding: .1em 0.3em;
+			margin: 0;
+
+			background: white;
+			box-shadow: 0 0 2px;
+			border: none;
+			border-top-right-radius: 1.33em;
+			background: white;
+		}
+		#toc-nav > #toc-jump {
+			padding-bottom: 2em;
+			margin-bottom: -1.9em;
+		}
+
+		#toc-nav > a:hover,
+		#toc-nav > a:focus {
+			background: #f8f8f8;
+		}
+		#toc-nav > a:not(:hover):not(:focus) {
+			color: #707070;
+		}
+
+		/* statusbar gets in the way on keyboard focus; remove once browsers fix */
+		#toc-nav > a[href="#toc"]:not(:hover):focus:last-child {
+			padding-bottom: 1.5rem;
+		}
+
+		#toc-nav:not(:hover) > a:not(:focus) > span + span {
+			/* Ideally this uses :focus-within on #toc-nav */
+			display: none;
+		}
+		#toc-nav > a > span + span {
+			padding-right: 0.2em;
+		}
+
+		#toc-toggle-inline {
+			vertical-align: 0.05em;
+			font-size: 80%;
+			color: gray;
+			color: hsla(203,20%,40%,.7);
+			border-style: none;
+			background: transparent;
+			position: relative;
+		}
+		#toc-toggle-inline:hover:not(:active),
+		#toc-toggle-inline:focus:not(:active) {
+			text-shadow: 1px 1px silver;
+			top: -1px;
+			left: -1px;
+		}
+
+		#toc-nav :active {
+			color: #C00;
+		}
+	}
+
+/** ToC Sidebar ***************************************************************/
+
+	/* Floating sidebar */
+	@media screen {
+		body.toc-sidebar #toc {
+			position: fixed;
+			top: 0; bottom: 0;
+			left: 0;
+			width: 23.5em;
+			max-width: 80%;
+			max-width: calc(100% - 2em - 26px);
+			overflow: auto;
+			padding: 0 1em;
+			padding-left: 42px;
+			padding-left: calc(1em + 26px);
+			background: inherit;
+			background-color: #f7f8f9;
+			z-index: 1;
+			box-shadow: -.1em 0 .25em rgba(0,0,0,.1) inset;
+		}
+		body.toc-sidebar #toc h2 {
+			margin-top: .8rem;
+			font-variant: small-caps;
+			font-variant: all-small-caps;
+			text-transform: lowercase;
+			font-weight: bold;
+			color: gray;
+			color: hsla(203,20%,40%,.7);
+		}
+		body.toc-sidebar #toc-jump:not(:focus) {
+			width: 0;
+			height: 0;
+			padding: 0;
+			position: absolute;
+			overflow: hidden;
+		}
+	}
+	/* Hide main scroller when only the ToC is visible anyway */
+	@media screen and (max-width: 28em) {
+		body.toc-sidebar {
+			overflow: hidden;
+		}
+	}
+
+	/* Sidebar with its own space */
+	@media screen and (min-width: 78em) {
+		body:not(.toc-inline) #toc {
+			position: fixed;
+			top: 0; bottom: 0;
+			left: 0;
+			width: 23.5em;
+			overflow: auto;
+			padding: 0 1em;
+			padding-left: 42px;
+			padding-left: calc(1em + 26px);
+			background: inherit;
+			background-color: #f7f8f9;
+			z-index: 1;
+			box-shadow: -.1em 0 .25em rgba(0,0,0,.1) inset;
+		}
+		body:not(.toc-inline) #toc h2 {
+			margin-top: .8rem;
+			font-variant: small-caps;
+			font-variant: all-small-caps;
+			text-transform: lowercase;
+			font-weight: bold;
+			color: gray;
+			color: hsla(203,20%,40%,.7);
+		}
+
+		body:not(.toc-inline) {
+			padding-left: 29em;
+		}
+		/* See also Overflow section at the bottom */
+
+		body:not(.toc-inline) #toc-jump:not(:focus) {
+			width: 0;
+			height: 0;
+			padding: 0;
+			position: absolute;
+			overflow: hidden;
+		}
+	}
+	@media screen and (min-width: 90em) {
+		body:not(.toc-inline) {
+			margin: 0 4em;
+		}
+	}
+
+/******************************************************************************/
+/*                                Sectioning                                  */
+/******************************************************************************/
+
+/** Headings ******************************************************************/
+
+	h1, h2, h3, h4, h5, h6, dt {
+		page-break-after: avoid;
+		page-break-inside: avoid;
+		font: 100% sans-serif;   /* Reset all font styling to clear out UA styles */
+		font-family: inherit;    /* Inherit the font family. */
+		line-height: 1.2;        /* Keep wrapped headings compact */
+		hyphens: manual;         /* Hyphenated headings look weird */
+	}
+
+	h2, h3, h4, h5, h6 {
+		margin-top: 3rem;
+	}
+
+	h1, h2, h3 {
+		color: #005A9C;
+		background: transparent;
+	}
+
+	h1 { font-size: 170%; }
+	h2 { font-size: 140%; }
+	h3 { font-size: 120%; }
+	h4 { font-weight: bold; }
+	h5 { font-style: italic; }
+	h6 { font-variant: small-caps; }
+	dt { font-weight: bold; }
+
+/** Subheadings ***************************************************************/
+
+	h1 + h2,
+	#subtitle {
+		/* #subtitle is a subtitle in an H2 under the H1 */
+		margin-top: 0;
+	}
+	h2 + h3,
+	h3 + h4,
+	h4 + h5,
+	h5 + h6 {
+		margin-top: 1.2em; /* = 1 x line-height */
+	}
+
+/** Section divider ***********************************************************/
+
+	:not(.head) > hr {
+		font-size: 1.5em;
+		text-align: center;
+		margin: 1em auto;
+		height: auto;
+		border: transparent solid 0;
+		background: transparent;
+	}
+	:not(.head) > hr::before {
+		content: "\2727\2003\2003\2727\2003\2003\2727";
+	}
+
+/******************************************************************************/
+/*                            Paragraphs and Lists                            */
+/******************************************************************************/
+
+	p {
+		margin: 1em 0;
+	}
+
+	dd > p:first-child,
+	li > p:first-child {
+		margin-top: 0;
+	}
+
+	ul, ol {
+		margin-left: 0;
+		padding-left: 2em;
+	}
+
+	li {
+		margin: 0.25em 0 0.5em;
+		padding: 0;
+	}
+
+	dl dd {
+		margin: 0 0 .5em 2em;
+	}
+
+	.head dd + dd { /* compact for header */
+		margin-top: -.5em;
+	}
+
+	/* Style for algorithms */
+	ol.algorithm ol:not(.algorithm),
+	.algorithm > ol ol:not(.algorithm) {
+	 border-left: 0.5em solid #DEF;
+	}
+
+	/* Put nice boxes around each algorithm. */
+	[data-algorithm]:not(.heading) {
+	  padding: .5em;
+	  border: thin solid #ddd; border-radius: .5em;
+	  margin: .5em calc(-0.5em - 1px);
+	}
+	[data-algorithm]:not(.heading) > :first-child {
+	  margin-top: 0;
+	}
+	[data-algorithm]:not(.heading) > :last-child {
+	  margin-bottom: 0;
+	}
+
+	/* Style for switch/case <dl>s */
+	dl.switch > dd > ol.only,
+	dl.switch > dd > .only > ol {
+	 margin-left: 0;
+	}
+	dl.switch > dd > ol.algorithm,
+	dl.switch > dd > .algorithm > ol {
+	 margin-left: -2em;
+	}
+	dl.switch {
+	 padding-left: 2em;
+	}
+	dl.switch > dt {
+	 text-indent: -1.5em;
+	 margin-top: 1em;
+	}
+	dl.switch > dt + dt {
+	 margin-top: 0;
+	}
+	dl.switch > dt::before {
+	 content: '\21AA';
+	 padding: 0 0.5em 0 0;
+	 display: inline-block;
+	 width: 1em;
+	 text-align: right;
+	 line-height: 0.5em;
+	}
+
+/** Terminology Markup ********************************************************/
+
+
+/******************************************************************************/
+/*                                 Inline Markup                              */
+/******************************************************************************/
+
+/** Terminology Markup ********************************************************/
+	dfn   { /* Defining instance */
+		font-weight: bolder;
+	}
+	a > i { /* Instance of term */
+		font-style: normal;
+	}
+	dt dfn code, code.idl {
+		font-size: normal;
+	}
+	dfn var {
+		font-style: normal;
+	}
+
+/** Change Marking ************************************************************/
+
+	del { color: red;  text-decoration: line-through; }
+	ins { color: #080; text-decoration: underline;    }
+
+/** Miscellaneous improvements to inline formatting ***************************/
+
+	sup {
+		vertical-align: super;
+		font-size: 80%
+	}
+
+/******************************************************************************/
+/*                                    Code                                    */
+/******************************************************************************/
+
+/** General monospace/pre rules ***********************************************/
+
+	pre, code, samp {
+		font-family: Menlo, Consolas, "DejaVu Sans Mono", Monaco, monospace;
+		font-size: .9em;
+		page-break-inside: avoid;
+		hyphens: none;
+		text-transform: none;
+	}
+	pre code,
+	code code {
+		font-size: 100%;
+	}
+
+	pre {
+		margin-top: 1em;
+		margin-bottom: 1em;
+		overflow: auto;
+	}
+
+/** Inline Code fragments *****************************************************/
+
+  /* Do something nice. */
+
+/******************************************************************************/
+/*                                    Links                                   */
+/******************************************************************************/
+
+/** General Hyperlinks ********************************************************/
+
+	/* We hyperlink a lot, so make it less intrusive */
+	a[href] {
+		color: #034575;
+		text-decoration: none;
+		border-bottom: 1px solid #707070;
+		/* Need a bit of extending for it to look okay */
+		padding: 0 1px 0;
+		margin: 0 -1px 0;
+	}
+	a:visited {
+		border-bottom-color: #BBB;
+	}
+
+	/* Use distinguishing colors when user is interacting with the link */
+	a[href]:focus,
+	a[href]:hover {
+		background: #f8f8f8;
+		background: rgba(75%, 75%, 75%, .25);
+		border-bottom-width: 3px;
+		margin-bottom: -2px;
+	}
+	a[href]:active {
+		color: #C00;
+		border-color: #C00;
+	}
+
+	/* Backout above styling for W3C logo */
+	.head .logo,
+	.head .logo a {
+		border: none;
+		text-decoration: none;
+		background: transparent;
+	}
+
+/******************************************************************************/
+/*                                    Images                                  */
+/******************************************************************************/
+
+	img {
+		border-style: none;
+	}
+
+	/* For autogen numbers, add
+	   .caption::before, figcaption::before { content: "Figure " counter(figure) ". "; }
+	*/
+
+	figure, .figure, .sidefigure {
+		page-break-inside: avoid;
+		text-align: center;
+		margin: 2.5em 0;
+	}
+	.figure img,    .sidefigure img,    figure img,
+	.figure object, .sidefigure object, figure object {
+		max-width: 100%;
+		margin: auto;
+	}
+	.figure pre, .sidefigure pre, figure pre {
+		text-align: left;
+		display: table;
+		margin: 1em auto;
+	}
+	.figure table, figure table {
+		margin: auto;
+	}
+	@media screen and (min-width: 20em) {
+		.sidefigure {
+			float: right;
+			width: 50%;
+			margin: 0 0 0.5em 0.5em
+		}
+	}
+	.caption, figcaption, caption {
+		font-style: italic;
+		font-size: 90%;
+	}
+	.caption::before, figcaption::before, figcaption > .marker {
+		font-weight: bold;
+	}
+	.caption, figcaption {
+		counter-increment: figure;
+	}
+
+	/* DL list is indented 2em, but figure inside it is not */
+	dd > .figure, dd > figure { margin-left: -2em }
+
+/******************************************************************************/
+/*                             Colored Boxes                                  */
+/******************************************************************************/
+
+	.issue, .note, .example, .assertion, .advisement, blockquote {
+		padding: .5em;
+		border: .5em;
+		border-left-style: solid;
+		page-break-inside: avoid;
+	}
+	span.issue, span.note {
+		padding: .1em .5em .15em;
+		border-right-style: solid;
+	}
+
+	.issue,
+	.note,
+	.example,
+	.advisement,
+	.assertion,
+	blockquote {
+		margin: 1em auto;
+	}
+	.note  > p:first-child,
+	.issue > p:first-child,
+	blockquote > :first-child {
+		margin-top: 0;
+	}
+	blockquote > :last-child {
+		margin-bottom: 0;
+	}
+
+/** Blockquotes ***************************************************************/
+
+	blockquote {
+		border-color: silver;
+	}
+
+/** Open issue ****************************************************************/
+
+	.issue {
+		border-color: #E05252;
+		background: #FBE9E9;
+		counter-increment: issue;
+		overflow: auto;
+	}
+	.issue::before, .issue > .marker {
+		text-transform: uppercase;
+		color: #AE1E1E;
+		padding-right: 1em;
+		text-transform: uppercase;
+	}
+	/* Add .issue::before { content: "Issue " counter(issue) " "; } for autogen numbers,
+	   or use class="marker" to mark up the issue number in source. */
+
+/** Example *******************************************************************/
+
+	.example {
+		border-color: #E0CB52;
+		background: #FCFAEE;
+		counter-increment: example;
+		overflow: auto;
+		clear: both;
+	}
+	.example::before, .example > .marker {
+		text-transform: uppercase;
+		color: #827017;
+		min-width: 7.5em;
+		display: block;
+	}
+	/* Add .example::before { content: "Example " counter(example) " "; } for autogen numbers,
+	   or use class="marker" to mark up the example number in source. */
+
+/** Non-normative Note ********************************************************/
+
+	.note {
+		border-color: #52E052;
+		background: #E9FBE9;
+		overflow: auto;
+	}
+
+	.note::before, .note > .marker,
+	details.note > summary::before,
+	details.note > summary > .marker {
+		text-transform: uppercase;
+		display: block;
+		color: hsl(120, 70%, 30%);
+	}
+	/* Add .note::before { content: "Note"; } for autogen label,
+	   or use class="marker" to mark up the label in source. */
+
+	details.note > summary {
+		display: block;
+		color: hsl(120, 70%, 30%);
+	}
+	details.note[open] > summary {
+		border-bottom: 1px silver solid;
+	}
+
+/** Assertion Box *************************************************************/
+	/*  for assertions in algorithms */
+
+	.assertion {
+		border-color: #AAA;
+		background: #EEE;
+	}
+
+/** Advisement Box ************************************************************/
+	/*  for attention-grabbing normative statements */
+
+	.advisement {
+		border-color: orange;
+		border-style: none solid;
+		background: #FFEECC;
+	}
+	strong.advisement {
+		display: block;
+		text-align: center;
+	}
+	.advisement > .marker {
+		color: #B35F00;
+	}
+
+/** Spec Obsoletion Notice ****************************************************/
+	/* obnoxious obsoletion notice for older/abandoned specs. */
+
+	details {
+		display: block;
+	}
+	summary {
+		font-weight: bolder;
+	}
+
+	.annoying-warning:not(details),
+	details.annoying-warning:not([open]) > summary,
+	details.annoying-warning[open] {
+		background: #fdd;
+		color: red;
+		font-weight: bold;
+		padding: .75em 1em;
+		border: thick red;
+		border-style: solid;
+		border-radius: 1em;
+	}
+	.annoying-warning :last-child {
+		margin-bottom: 0;
+	}
+
+@media not print {
+	details.annoying-warning[open] {
+		position: fixed;
+		left: 1em;
+		right: 1em;
+		bottom: 1em;
+		z-index: 1000;
+	}
+}
+
+	details.annoying-warning:not([open]) > summary {
+		text-align: center;
+	}
+
+/** Entity Definition Boxes ***************************************************/
+
+	.def {
+		padding: .5em 1em;
+		background: #DEF;
+		margin: 1.2em 0;
+		border-left: 0.5em solid #8CCBF2;
+	}
+
+/******************************************************************************/
+/*                                    Tables                                  */
+/******************************************************************************/
+
+	th, td {
+		text-align: left;
+		text-align: start;
+	}
+
+/** Property/Descriptor Definition Tables *************************************/
+
+	table.def {
+		/* inherits .def box styling, see above */
+		width: 100%;
+		border-spacing: 0;
+	}
+
+	table.def td,
+	table.def th {
+		padding: 0.5em;
+		vertical-align: baseline;
+		border-bottom: 1px solid #bbd7e9;
+	}
+
+	table.def > tbody > tr:last-child th,
+	table.def > tbody > tr:last-child td {
+		border-bottom: 0;
+	}
+
+	table.def th {
+		font-style: italic;
+		font-weight: normal;
+		padding-left: 1em;
+		width: 3em;
+	}
+
+	/* For when values are extra-complex and need formatting for readability */
+	table td.pre {
+		white-space: pre-wrap;
+	}
+
+	/* A footnote at the bottom of a def table */
+	table.def           td.footnote {
+		padding-top: 0.6em;
+	}
+	table.def           td.footnote::before {
+		content: " ";
+		display: block;
+		height: 0.6em;
+		width: 4em;
+		border-top: thin solid;
+	}
+
+/** Data tables (and properly marked-up index tables) *************************/
+	/*
+		 <table class="data"> highlights structural relationships in a table
+		 when correct markup is used (e.g. thead/tbody, th vs. td, scope attribute)
+
+		 Use class="complex data" for particularly complicated tables --
+		 (This will draw more lines: busier, but clearer.)
+
+		 Use class="long" on table cells with paragraph-like contents
+		 (This will adjust text alignment accordingly.)
+		 Alternately use class="longlastcol" on tables, to have the last column assume "long".
+	*/
+
+	table {
+		word-wrap: normal;
+		overflow-wrap: normal;
+		hyphens: manual;
+	}
+
+	table.data,
+	table.index {
+		margin: 1em auto;
+		border-collapse: collapse;
+		border: hidden;
+		width: 100%;
+	}
+	table.data caption,
+	table.index caption {
+		max-width: 50em;
+		margin: 0 auto 1em;
+	}
+
+	table.data td,  table.data th,
+	table.index td, table.index th {
+		padding: 0.5em 1em;
+		border-width: 1px;
+		border-color: silver;
+		border-top-style: solid;
+	}
+
+	table.data thead td:empty {
+		padding: 0;
+		border: 0;
+	}
+
+	table.data  thead,
+	table.index thead,
+	table.data  tbody,
+	table.index tbody {
+		border-bottom: 2px solid;
+	}
+
+	table.data colgroup,
+	table.index colgroup {
+		border-left: 2px solid;
+	}
+
+	table.data  tbody th:first-child,
+	table.index tbody th:first-child  {
+		border-right: 2px solid;
+		border-top: 1px solid silver;
+		padding-right: 1em;
+	}
+
+	table.data th[colspan],
+	table.data td[colspan] {
+		text-align: center;
+	}
+
+	table.complex.data th,
+	table.complex.data td {
+		border: 1px solid silver;
+		text-align: center;
+	}
+
+	table.data.longlastcol td:last-child,
+	table.data td.long {
+	 vertical-align: baseline;
+	 text-align: left;
+	}
+
+	table.data img {
+		vertical-align: middle;
+	}
+
+
+/*
+Alternate table alignment rules
+
+	table.data,
+	table.index {
+		text-align: center;
+	}
+
+	table.data  thead th[scope="row"],
+	table.index thead th[scope="row"] {
+		text-align: right;
+	}
+
+	table.data  tbody th:first-child,
+	table.index tbody th:first-child  {
+		text-align: right;
+	}
+
+Possible extra rowspan handling
+
+	table.data  tbody th[rowspan]:not([rowspan='1']),
+	table.index tbody th[rowspan]:not([rowspan='1']),
+	table.data  tbody td[rowspan]:not([rowspan='1']),
+	table.index tbody td[rowspan]:not([rowspan='1']) {
+		border-left: 1px solid silver;
+	}
+
+	table.data  tbody th[rowspan]:first-child,
+	table.index tbody th[rowspan]:first-child,
+	table.data  tbody td[rowspan]:first-child,
+	table.index tbody td[rowspan]:first-child{
+		border-left: 0;
+		border-right: 1px solid silver;
+	}
+*/
+
+/******************************************************************************/
+/*                                  Indices                                   */
+/******************************************************************************/
+
+
+/** Table of Contents *********************************************************/
+
+	.toc a {
+		/* More spacing; use padding to make it part of the click target. */
+		padding-top: 0.1rem;
+		/* Larger, more consistently-sized click target */
+		display: block;
+		/* Reverse color scheme */
+		color: black;
+		border-color: #3980B5;
+		border-bottom-width: 3px !important;
+		margin-bottom: 0px !important;
+	}
+	.toc a:visited {
+		border-color: #054572;
+	}
+	.toc a:not(:focus):not(:hover) {
+		/* Allow colors to cascade through from link styling */
+		border-bottom-color: transparent;
+	}
+
+	.toc, .toc ol, .toc ul, .toc li {
+		list-style: none; /* Numbers must be inlined into source */
+		/* because generated content isn't search/selectable and markers can't do multilevel yet */
+		margin:  0;
+		padding: 0;
+		line-height: 1.1rem; /* consistent spacing */
+	}
+
+	/* ToC not indented until third level, but font style & margins show hierarchy */
+	.toc > li             { font-weight: bold;   }
+	.toc > li li          { font-weight: normal; }
+	.toc > li li li       { font-size:   95%;    }
+	.toc > li li li li    { font-size:   90%;    }
+	.toc > li li li li li { font-size:   85%;    }
+
+	.toc > li             { margin: 1.5rem 0;    }
+	.toc > li li          { margin: 0.3rem 0;    }
+	.toc > li li li       { margin-left: 2rem;   }
+
+	/* Section numbers in a column of their own */
+	.toc .secno {
+		float: left;
+		width: 4rem;
+		white-space: nowrap;
+	}
+	.toc > li li li li .secno {
+		font-size: 85%;
+	}
+	.toc > li li li li li .secno {
+		font-size: 100%;
+	}
+
+	:not(li) > .toc              { margin-left:  5rem; }
+	.toc .secno                  { margin-left: -5rem; }
+	.toc > li li li .secno       { margin-left: -7rem; }
+	.toc > li li li li .secno    { margin-left: -9rem; }
+	.toc > li li li li li .secno { margin-left: -11rem; }
+
+	/* Tighten up indentation in narrow ToCs */
+	@media (max-width: 30em) {
+		:not(li) > .toc              { margin-left:  4rem; }
+		.toc .secno                  { margin-left: -4rem; }
+		.toc > li li li              { margin-left:  1rem; }
+		.toc > li li li .secno       { margin-left: -5rem; }
+		.toc > li li li li .secno    { margin-left: -6rem; }
+		.toc > li li li li li .secno { margin-left: -7rem; }
+	}
+	@media screen and (min-width: 78em) {
+		body:not(.toc-inline) :not(li) > .toc              { margin-left:  4rem; }
+		body:not(.toc-inline) .toc .secno                  { margin-left: -4rem; }
+		body:not(.toc-inline) .toc > li li li              { margin-left:  1rem; }
+		body:not(.toc-inline) .toc > li li li .secno       { margin-left: -5rem; }
+		body:not(.toc-inline) .toc > li li li li .secno    { margin-left: -6rem; }
+		body:not(.toc-inline) .toc > li li li li li .secno { margin-left: -7rem; }
+	}
+	body.toc-sidebar #toc :not(li) > .toc              { margin-left:  4rem; }
+	body.toc-sidebar #toc .toc .secno                  { margin-left: -4rem; }
+	body.toc-sidebar #toc .toc > li li li              { margin-left:  1rem; }
+	body.toc-sidebar #toc .toc > li li li .secno       { margin-left: -5rem; }
+	body.toc-sidebar #toc .toc > li li li li .secno    { margin-left: -6rem; }
+	body.toc-sidebar #toc .toc > li li li li li .secno { margin-left: -7rem; }
+
+	.toc li {
+		clear: both;
+	}
+
+
+/** Index *********************************************************************/
+
+	/* Index Lists: Layout */
+	ul.index       { margin-left: 0; columns: 15em; text-indent: 1em hanging; }
+	ul.index li    { margin-left: 0; list-style: none; break-inside: avoid; }
+	ul.index li li { margin-left: 1em }
+	ul.index dl    { margin-top: 0; }
+	ul.index dt    { margin: .2em 0 .2em 20px;}
+	ul.index dd    { margin: .2em 0 .2em 40px;}
+	/* Index Lists: Typography */
+	ul.index ul,
+	ul.index dl { font-size: smaller; }
+	@media not print {
+		ul.index li span {
+			white-space: nowrap;
+			color: transparent; }
+		ul.index li a:hover + span,
+		ul.index li a:focus + span {
+			color: #707070;
+		}
+	}
+
+/** Index Tables *****************************************************/
+	/* See also the data table styling section, which this effectively subclasses */
+
+	table.index {
+		font-size: small;
+		border-collapse: collapse;
+		border-spacing: 0;
+		text-align: left;
+		margin: 1em 0;
+	}
+
+	table.index td,
+	table.index th {
+		padding: 0.4em;
+	}
+
+	table.index tr:hover td:not([rowspan]),
+	table.index tr:hover th:not([rowspan]) {
+		background: #f7f8f9;
+	}
+
+	/* The link in the first column in the property table (formerly a TD) */
+	table.index th:first-child a {
+		font-weight: bold;
+	}
+
+/******************************************************************************/
+/*                                    Print                                   */
+/******************************************************************************/
+
+	@media print {
+		/* Pages have their own margins. */
+		html {
+			margin: 0;
+		}
+		/* Serif for print. */
+		body {
+			font-family: serif;
+		}
+	}
+	@page {
+		margin: 1.5cm 1.1cm;
+	}
+
+/******************************************************************************/
+/*                                    Legacy                                  */
+/******************************************************************************/
+
+	/* This rule is inherited from past style sheets. No idea what it's for. */
+	.hide { display: none }
+
+
+
+/******************************************************************************/
+/*                             Overflow Control                               */
+/******************************************************************************/
+
+	.figure .caption, .sidefigure .caption, figcaption {
+		/* in case figure is overlarge, limit caption to 50em */
+		max-width: 50rem;
+		margin-left: auto;
+		margin-right: auto;
+	}
+	.overlarge > table {
+		/* limit preferred width of table */
+		max-width: 50em;
+		margin-left: auto;
+		margin-right: auto;
+	}
+
+	@media (min-width: 55em) {
+		.overlarge {
+			margin-left: calc(13px + 26.5rem - 50vw);
+			margin-right: calc(13px + 26.5rem - 50vw);
+			max-width: none;
+		}
+	}
+	@media screen and (min-width: 78em) {
+		body:not(.toc-inline) .overlarge {
+			/* 30.5em body padding 50em content area */
+			margin-left: calc(40em - 50vw) !important;
+			margin-right: calc(40em - 50vw) !important;
+		}
+	}
+	@media screen and (min-width: 90em) {
+		body:not(.toc-inline) .overlarge {
+			/* 4em html margin 30.5em body padding 50em content area */
+			margin-left: 0 !important;
+			margin-right: calc(84.5em - 100vw) !important;
+		}
+	}
+
+	@media not print {
+		.overlarge {
+			overflow-x: auto;
+			/* See Lea Verou's explanation background-attachment:
+			 * http://lea.verou.me/2012/04/background-attachment-local/
+			 *
+			background: top left  / 4em 100% linear-gradient(to right,  #ffffff, rgba(255, 255, 255, 0)) local,
+			            top right / 4em 100% linear-gradient(to left, #ffffff, rgba(255, 255, 255, 0)) local,
+			            top left  / 1em 100% linear-gradient(to right,  #c3c3c5, rgba(195, 195, 197, 0)) scroll,
+			            top right / 1em 100% linear-gradient(to left, #c3c3c5, rgba(195, 195, 197, 0)) scroll,
+			            white;
+			background-repeat: no-repeat;
+			*/
+		}
+	}
+</style>
+  <meta content="Bikeshed version 34209db86579ed3f0e75afb470f2788a2646155f" name="generator">
+  <link href="https://wicg.github.io/picture-in-picture" rel="canonical">
+<style>/* style-md-lists */
+
+            /* This is a weird hack for me not yet following the commonmark spec
+               regarding paragraph and lists. */
+            [data-md] > :first-child {
+                margin-top: 0;
+            }
+            [data-md] > :last-child {
+                margin-bottom: 0;
+            }</style>
+<style>/* style-selflinks */
+
+            .heading, .issue, .note, .example, li, dt {
+                position: relative;
+            }
+            a.self-link {
+                position: absolute;
+                top: 0;
+                left: calc(-1 * (3.5rem - 26px));
+                width: calc(3.5rem - 26px);
+                height: 2em;
+                text-align: center;
+                border: none;
+                transition: opacity .2s;
+                opacity: .5;
+            }
+            a.self-link:hover {
+                opacity: 1;
+            }
+            .heading > a.self-link {
+                font-size: 83%;
+            }
+            li > a.self-link {
+                left: calc(-1 * (3.5rem - 26px) - 2em);
+            }
+            dfn > a.self-link {
+                top: auto;
+                left: auto;
+                opacity: 0;
+                width: 1.5em;
+                height: 1.5em;
+                background: gray;
+                color: white;
+                font-style: normal;
+                transition: opacity .2s, background-color .2s, color .2s;
+            }
+            dfn:hover > a.self-link {
+                opacity: 1;
+            }
+            dfn > a.self-link:hover {
+                color: black;
+            }
+
+            a.self-link::before            { content: "¶"; }
+            .heading > a.self-link::before { content: "§"; }
+            dfn > a.self-link::before      { content: "#"; }</style>
+<style>/* style-counters */
+
+            body {
+                counter-reset: example figure issue;
+            }
+            .issue {
+                counter-increment: issue;
+            }
+            .issue:not(.no-marker)::before {
+                content: "Issue " counter(issue);
+            }
+
+            .example {
+                counter-increment: example;
+            }
+            .example:not(.no-marker)::before {
+                content: "Example " counter(example);
+            }
+            .invalid.example:not(.no-marker)::before,
+            .illegal.example:not(.no-marker)::before {
+                content: "Invalid Example" counter(example);
+            }
+
+            figcaption {
+                counter-increment: figure;
+            }
+            figcaption:not(.no-marker)::before {
+                content: "Figure " counter(figure) " ";
+            }</style>
+<style>/* style-autolinks */
+
+            .css.css, .property.property, .descriptor.descriptor {
+                color: #005a9c;
+                font-size: inherit;
+                font-family: inherit;
+            }
+            .css::before, .property::before, .descriptor::before {
+                content: "‘";
+            }
+            .css::after, .property::after, .descriptor::after {
+                content: "’";
+            }
+            .property, .descriptor {
+                /* Don't wrap property and descriptor names */
+                white-space: nowrap;
+            }
+            .type { /* CSS value <type> */
+                font-style: italic;
+            }
+            pre .property::before, pre .property::after {
+                content: "";
+            }
+            [data-link-type="property"]::before,
+            [data-link-type="propdesc"]::before,
+            [data-link-type="descriptor"]::before,
+            [data-link-type="value"]::before,
+            [data-link-type="function"]::before,
+            [data-link-type="at-rule"]::before,
+            [data-link-type="selector"]::before,
+            [data-link-type="maybe"]::before {
+                content: "‘";
+            }
+            [data-link-type="property"]::after,
+            [data-link-type="propdesc"]::after,
+            [data-link-type="descriptor"]::after,
+            [data-link-type="value"]::after,
+            [data-link-type="function"]::after,
+            [data-link-type="at-rule"]::after,
+            [data-link-type="selector"]::after,
+            [data-link-type="maybe"]::after {
+                content: "’";
+            }
+
+            [data-link-type].production::before,
+            [data-link-type].production::after,
+            .prod [data-link-type]::before,
+            .prod [data-link-type]::after {
+                content: "";
+            }
+
+            [data-link-type=element],
+            [data-link-type=element-attr] {
+                font-family: Menlo, Consolas, "DejaVu Sans Mono", monospace;
+                font-size: .9em;
+            }
+            [data-link-type=element]::before { content: "<" }
+            [data-link-type=element]::after  { content: ">" }
+
+            [data-link-type=biblio] {
+                white-space: pre;
+            }</style>
+<style>/* style-dfn-panel */
+
+        .dfn-panel {
+            position: absolute;
+            z-index: 35;
+            height: auto;
+            width: -webkit-fit-content;
+            width: fit-content;
+            max-width: 300px;
+            max-height: 500px;
+            overflow: auto;
+            padding: 0.5em 0.75em;
+            font: small Helvetica Neue, sans-serif, Droid Sans Fallback;
+            background: #DDDDDD;
+            color: black;
+            border: outset 0.2em;
+        }
+        .dfn-panel:not(.on) { display: none; }
+        .dfn-panel * { margin: 0; padding: 0; text-indent: 0; }
+        .dfn-panel > b { display: block; }
+        .dfn-panel a { color: black; }
+        .dfn-panel a:not(:hover) { text-decoration: none !important; border-bottom: none !important; }
+        .dfn-panel > b + b { margin-top: 0.25em; }
+        .dfn-panel ul { padding: 0; }
+        .dfn-panel li { list-style: inside; }
+        .dfn-panel.activated {
+            display: inline-block;
+            position: fixed;
+            left: .5em;
+            bottom: 2em;
+            margin: 0 auto;
+            max-width: calc(100vw - 1.5em - .4em - .5em);
+            max-height: 30vh;
+        }
+
+        .dfn-paneled { cursor: pointer; }
+        </style>
+<style>/* style-syntax-highlighting */
+pre.idl.highlight { color: #708090; }
+        .highlight:not(.idl) { background: hsl(24, 20%, 95%); }
+        code.highlight { padding: .1em; border-radius: .3em; }
+        pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em 0; overflow: auto; border-radius: 0; }
+        .highlight .c { color: #708090 } /* Comment */
+        .highlight .k { color: #990055 } /* Keyword */
+        .highlight .l { color: #000000 } /* Literal */
+        .highlight .n { color: #0077aa } /* Name */
+        .highlight .o { color: #999999 } /* Operator */
+        .highlight .p { color: #999999 } /* Punctuation */
+        .highlight .cm { color: #708090 } /* Comment.Multiline */
+        .highlight .cp { color: #708090 } /* Comment.Preproc */
+        .highlight .c1 { color: #708090 } /* Comment.Single */
+        .highlight .cs { color: #708090 } /* Comment.Special */
+        .highlight .kc { color: #990055 } /* Keyword.Constant */
+        .highlight .kd { color: #990055 } /* Keyword.Declaration */
+        .highlight .kn { color: #990055 } /* Keyword.Namespace */
+        .highlight .kp { color: #990055 } /* Keyword.Pseudo */
+        .highlight .kr { color: #990055 } /* Keyword.Reserved */
+        .highlight .kt { color: #990055 } /* Keyword.Type */
+        .highlight .ld { color: #000000 } /* Literal.Date */
+        .highlight .m { color: #000000 } /* Literal.Number */
+        .highlight .s { color: #a67f59 } /* Literal.String */
+        .highlight .na { color: #0077aa } /* Name.Attribute */
+        .highlight .nc { color: #0077aa } /* Name.Class */
+        .highlight .no { color: #0077aa } /* Name.Constant */
+        .highlight .nd { color: #0077aa } /* Name.Decorator */
+        .highlight .ni { color: #0077aa } /* Name.Entity */
+        .highlight .ne { color: #0077aa } /* Name.Exception */
+        .highlight .nf { color: #0077aa } /* Name.Function */
+        .highlight .nl { color: #0077aa } /* Name.Label */
+        .highlight .nn { color: #0077aa } /* Name.Namespace */
+        .highlight .py { color: #0077aa } /* Name.Property */
+        .highlight .nt { color: #669900 } /* Name.Tag */
+        .highlight .nv { color: #222222 } /* Name.Variable */
+        .highlight .ow { color: #999999 } /* Operator.Word */
+        .highlight .mb { color: #000000 } /* Literal.Number.Bin */
+        .highlight .mf { color: #000000 } /* Literal.Number.Float */
+        .highlight .mh { color: #000000 } /* Literal.Number.Hex */
+        .highlight .mi { color: #000000 } /* Literal.Number.Integer */
+        .highlight .mo { color: #000000 } /* Literal.Number.Oct */
+        .highlight .sb { color: #a67f59 } /* Literal.String.Backtick */
+        .highlight .sc { color: #a67f59 } /* Literal.String.Char */
+        .highlight .sd { color: #a67f59 } /* Literal.String.Doc */
+        .highlight .s2 { color: #a67f59 } /* Literal.String.Double */
+        .highlight .se { color: #a67f59 } /* Literal.String.Escape */
+        .highlight .sh { color: #a67f59 } /* Literal.String.Heredoc */
+        .highlight .si { color: #a67f59 } /* Literal.String.Interpol */
+        .highlight .sx { color: #a67f59 } /* Literal.String.Other */
+        .highlight .sr { color: #a67f59 } /* Literal.String.Regex */
+        .highlight .s1 { color: #a67f59 } /* Literal.String.Single */
+        .highlight .ss { color: #a67f59 } /* Literal.String.Symbol */
+        .highlight .vc { color: #0077aa } /* Name.Variable.Class */
+        .highlight .vg { color: #0077aa } /* Name.Variable.Global */
+        .highlight .vi { color: #0077aa } /* Name.Variable.Instance */
+        .highlight .il { color: #000000 } /* Literal.Number.Integer.Long */
+        </style>
+ <body class="h-entry">
+  <div class="head">
+   <p data-fill-with="logo"></p>
+   <h1 class="p-name no-ref" id="title">Picture In Picture</h1>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-06-01">1 June 2017</time></span></h2>
+   <div data-fill-with="spec-metadata">
+    <dl>
+     <dt>This version:
+     <dd><a class="u-url" href="https://wicg.github.io/picture-in-picture">https://wicg.github.io/picture-in-picture</a>
+     <dt>Issue Tracking:
+     <dd><a href="https://github.com/beaufortfrancois/picture-in-picture/issues/">GitHub</a>
+     <dt class="editor">Editors:
+     <dd class="editor p-author h-card vcard"><a class="p-name fn u-email email" href="mailto:fbeaufort@google.com">François Beaufort</a> (<span class="p-org org">Google</span>)
+     <dd class="editor p-author h-card vcard"><a class="p-name fn u-email email" href="mailto:mlamouri@google.com">Mounir Lamouri</a> (<span class="p-org org">Google</span>)
+    </dl>
+   </div>
+   <div data-fill-with="warning"></div>
+   <p class="copyright" data-fill-with="copyright"><a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2017 the Contributors to the Picture In Picture Specification, published by the <a href="https://www.w3.org/community/wicg/">Web Platform Incubator Community Group</a> under the <a href="https://www.w3.org/community/about/agreements/cla/">W3C Community Contributor License Agreement (CLA)</a>.
+A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/">summary</a> is available. </p>
+   <hr title="Separator for header">
+  </div>
+  <div class="p-summary" data-fill-with="abstract">
+   <h2 class="no-num no-toc no-ref heading settled" id="abstract"><span class="content">Abstract</span></h2>
+   <p>This specification intends to provide APIs to allow websites to
+
+create a floating video window over the desktop.</p>
+  </div>
+  <div data-fill-with="at-risk"></div>
+  <h2 class="no-num no-toc no-ref heading settled" id="status"><span class="content">Status of this document</span></h2>
+  <div data-fill-with="status">
+   <p> This specification was published by the <a href="https://www.w3.org/community/wicg/">Web Platform Incubator Community Group</a>.
+  It is not a W3C Standard nor is it on the W3C Standards Track.
+
+  Please note that under the <a href="https://www.w3.org/community/about/agreements/cla/">W3C Community Contributor License Agreement (CLA)</a> there is a limited opt-out and other conditions apply.
+
+  Learn more about <a href="http://www.w3.org/community/">W3C Community and Business Groups</a>. </p>
+   <p></p>
+  </div>
+  <div data-fill-with="at-risk"></div>
+  <nav data-fill-with="table-of-contents" id="toc">
+   <h2 class="no-num no-toc no-ref" id="contents">Table of Contents</h2>
+   <ol class="toc" role="directory">
+    <li><a href="#intro"><span class="secno">1</span> <span class="content">Introduction</span></a>
+    <li>
+     <a href="#api"><span class="secno">2</span> <span class="content">API</span></a>
+     <ol class="toc">
+      <li><a href="#example"><span class="secno">2.1</span> <span class="content">Example</span></a>
+      <li><a href="#htmlvideoelement-extension"><span class="secno">2.2</span> <span class="content"><code>HTMLVideoElement</code> extension</span></a>
+      <li><a href="#document-extension"><span class="secno">2.3</span> <span class="content"><code>Document</code> and <code>DocumentOrShadowRoot</code> extension</span></a>
+      <li><a href="#event-types"><span class="secno">2.4</span> <span class="content">Event types</span></a>
+     </ol>
+    <li>
+     <a href="#integration"><span class="secno">3</span> <span class="content">Integration</span></a>
+     <ol class="toc">
+      <li><a href="#remote-playback"><span class="secno">3.1</span> <span class="content">Interaction with remote playback</span></a>
+      <li><a href="#one-pip-window"><span class="secno">3.2</span> <span class="content">One Picture in Picture window</span></a>
+      <li><a href="#feature-policy"><span class="secno">3.3</span> <span class="content">Feature Policy</span></a>
+     </ol>
+    <li><a href="#conformance"><span class="secno"></span> <span class="content"> Conformance</span></a>
+    <li>
+     <a href="#index"><span class="secno"></span> <span class="content">Index</span></a>
+     <ol class="toc">
+      <li><a href="#index-defined-here"><span class="secno"></span> <span class="content">Terms defined by this specification</span></a>
+      <li><a href="#index-defined-elsewhere"><span class="secno"></span> <span class="content">Terms defined by reference</span></a>
+     </ol>
+    <li>
+     <a href="#references"><span class="secno"></span> <span class="content">References</span></a>
+     <ol class="toc">
+      <li><a href="#normative"><span class="secno"></span> <span class="content">Normative References</span></a>
+     </ol>
+    <li><a href="#idl-index"><span class="secno"></span> <span class="content">IDL Index</span></a>
+   </ol>
+  </nav>
+  <main>
+   <h2 class="heading settled" data-level="1" id="intro"><span class="secno">1. </span><span class="content">Introduction</span><a class="self-link" href="#intro"></a></h2>
+   <p><em>This section is non-normative.</em></p>
+   <p>Many users want to continue consuming media while they interact with other
+content, sites, or applications on their device. A common UI affordance for
+this type of activity is Picture in Picture, where the video is contained in a
+separate miniature window that is viewable above all other activities. Most
+desktop and mobile OSs have announced or released platform-level support for
+Picture In Picture, as have many browsers.</p>
+   <p>This specification aims to allow websites to initiate and control this behavior
+by exposing the following sets of properties to the API:</p>
+   <ul>
+    <li data-md="">
+     <p>Notify the website when it enters and leave Picture in Picture mode.</p>
+    <li data-md="">
+     <p>Allow the website to trigger Picture in Picture via a user gesture on a video element.</p>
+    <li data-md="">
+     <p>Allow the website to exit Picture in Picture.</p>
+    <li data-md="">
+     <p>Allow the website to check if Picture in Picture can be triggered.</p>
+    <li data-md="">
+     <p>Take a hint for the preferred window size and position which could be ignored by the user agent.</p>
+   </ul>
+   <h2 class="heading settled" data-level="2" id="api"><span class="secno">2. </span><span class="content">API</span><a class="self-link" href="#api"></a></h2>
+   <p>The proposed Picture In Picture API is very similar to the <a data-link-type="dfn">Fullscreen
+API</a> as they have similar properties. The API only applies on <a data-link-type="dfn"><code>HTMLVideoElement</code></a> at the moment but is meant to be
+extensible.</p>
+   <h3 class="heading settled" data-level="2.1" id="example"><span class="secno">2.1. </span><span class="content">Example</span><a class="self-link" href="#example"></a></h3>
+<pre class="language-html highlight"><span class="p">&lt;</span><span class="nt">video</span> <span class="na">id</span><span class="o">=</span><span class="s">"video"</span> <span class="na">src</span><span class="o">=</span><span class="s">"https://example.com/video.mp4"</span><span class="p">></span><span class="p">&lt;</span><span class="p">/</span><span class="nt">video</span><span class="p">></span>
+<span class="p">&lt;</span><span class="nt">button</span> <span class="na">id</span><span class="o">=</span><span class="s">"pipButton"</span><span class="p">></span><span class="p">&lt;</span><span class="p">/</span><span class="nt">button</span><span class="p">></span>
+
+<span class="p">&lt;</span><span class="nt">script</span><span class="p">></span>
+  pipButton<span class="p">.</span>hidden <span class="o">=</span> <span class="o">!</span>document<span class="p">.</span>pictureInPictureEnabled<span class="p">;</span>
+
+  pipButton<span class="p">.</span>addEventListener<span class="p">(</span><span class="s1">'click'</span><span class="p">,</span> <span class="kd">function</span><span class="p">(</span><span class="p">)</span> <span class="p">{</span>
+    <span class="k">if</span> <span class="p">(</span><span class="o">!</span>document<span class="p">.</span>pictureInPictureElement<span class="p">)</span> <span class="p">{</span>
+      video<span class="p">.</span>requestPictureInPicture<span class="p">(</span><span class="p">)</span><span class="p">.</span><span class="k">catch</span><span class="p">(</span>error <span class="p">=></span> <span class="p">{</span>
+        <span class="c1">// Video failed to enter Picture In Picture mode.
+</span>      <span class="p">}</span><span class="p">)</span><span class="p">;</span>
+    <span class="p">}</span> <span class="k">else</span> <span class="p">{</span>
+      document<span class="p">.</span>exitPictureInPicture<span class="p">(</span><span class="p">)</span><span class="p">.</span><span class="k">catch</span><span class="p">(</span>error <span class="p">=></span> <span class="p">{</span>
+        <span class="c1">// Video failed to leave Picture In Picture mode.
+</span>      <span class="p">}</span><span class="p">)</span><span class="p">;</span>
+    <span class="p">}</span>
+  <span class="p">}</span><span class="p">)</span><span class="p">;</span>
+
+  video<span class="p">.</span>addEventListener<span class="p">(</span><span class="s1">'enterpictureinpicture'</span><span class="p">,</span> <span class="kd">function</span><span class="p">(</span><span class="p">)</span> <span class="p">{</span>
+    <span class="c1">// Video entered Picture In Picture mode.
+</span>  <span class="p">}</span><span class="p">)</span><span class="p">;</span>
+
+  video<span class="p">.</span>addEventListener<span class="p">(</span><span class="s1">'leavepictureinpicture'</span><span class="p">,</span> <span class="kd">function</span><span class="p">(</span><span class="p">)</span> <span class="p">{</span>
+    <span class="c1">// Video left Picture In Picture mode.
+</span>  <span class="p">}</span><span class="p">)</span><span class="p">;</span>
+<span class="p">&lt;</span><span class="p">/</span><span class="nt">script</span><span class="p">></span>
+</pre>
+   <h3 class="heading settled" data-level="2.2" id="htmlvideoelement-extension"><span class="secno">2.2. </span><span class="content"><code>HTMLVideoElement</code> extension</span><a class="self-link" href="#htmlvideoelement-extension"></a></h3>
+<pre class="idl highlight def"><span class="kt">dictionary</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="dictionary" data-export="" id="dictdef-pictureinpictureoptions"><code>PictureInPictureOptions</code></dfn> {
+  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long"><span class="kt">unsigned</span> <span class="kt">long</span></a> <dfn class="nv dfn-paneled idl-code" data-dfn-for="PictureInPictureOptions" data-dfn-type="dict-member" data-export="" data-type="unsigned long " id="dom-pictureinpictureoptions-width"><code>width</code></dfn>;
+  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long"><span class="kt">unsigned</span> <span class="kt">long</span></a> <dfn class="nv dfn-paneled idl-code" data-dfn-for="PictureInPictureOptions" data-dfn-type="dict-member" data-export="" data-type="unsigned long " id="dom-pictureinpictureoptions-height"><code>height</code></dfn>;
+  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long"><span class="kt">unsigned</span> <span class="kt">long</span></a> <dfn class="nv dfn-paneled idl-code" data-dfn-for="PictureInPictureOptions" data-dfn-type="dict-member" data-export="" data-type="unsigned long " id="dom-pictureinpictureoptions-top"><code>top</code></dfn>;
+  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long"><span class="kt">unsigned</span> <span class="kt">long</span></a> <dfn class="nv dfn-paneled idl-code" data-dfn-for="PictureInPictureOptions" data-dfn-type="dict-member" data-export="" data-type="unsigned long " id="dom-pictureinpictureoptions-start"><code>start</code></dfn>;
+};
+</pre>
+<pre class="idl highlight def"><span class="kt">partial</span> <span class="kt">interface</span> <a class="nv idl-code" data-link-type="interface" href="https://html.spec.whatwg.org/multipage/embedded-content.html#htmlvideoelement">HTMLVideoElement</a> {
+  <span class="kt">Promise</span>&lt;<span class="kt">void</span>> <dfn class="nv dfn-paneled idl-code" data-dfn-for="HTMLVideoElement" data-dfn-type="method" data-export="" data-lt="requestPictureInPicture(options)|requestPictureInPicture()" id="dom-htmlvideoelement-requestpictureinpicture"><code>requestPictureInPicture</code></dfn>(<span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="#dictdef-pictureinpictureoptions" id="ref-for-dictdef-pictureinpictureoptions-1">PictureInPictureOptions</a> <dfn class="nv idl-code" data-dfn-for="HTMLVideoElement/requestPictureInPicture(options), HTMLVideoElement/requestPictureInPicture()" data-dfn-type="argument" data-export="" id="dom-htmlvideoelement-requestpictureinpicture-options-options"><code>options</code><a class="self-link" href="#dom-htmlvideoelement-requestpictureinpicture-options-options"></a></dfn>);
+
+  <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">EventHandler</a> <dfn class="nv idl-code" data-dfn-for="HTMLVideoElement" data-dfn-type="attribute" data-export="" data-type="EventHandler" id="dom-htmlvideoelement-onenterpictureinpicture"><code>onenterpictureinpicture</code><a class="self-link" href="#dom-htmlvideoelement-onenterpictureinpicture"></a></dfn>;
+  <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">EventHandler</a> <dfn class="nv idl-code" data-dfn-for="HTMLVideoElement" data-dfn-type="attribute" data-export="" data-type="EventHandler" id="dom-htmlvideoelement-onleavepictureinpicture"><code>onleavepictureinpicture</code><a class="self-link" href="#dom-htmlvideoelement-onleavepictureinpicture"></a></dfn>;
+};
+</pre>
+   <p>The <code class="idl"><a data-link-type="idl" href="#dom-htmlvideoelement-requestpictureinpicture" id="ref-for-dom-htmlvideoelement-requestpictureinpicture-1">requestPictureInPicture()</a></code> method, when invoked, MUST
+return <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#a-new-promise">a new promise</a> <var>promise</var> and run the following steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in
+parallel</a>:</p>
+   <ol>
+    <li data-md="">
+     <p>If <code class="idl"><a data-link-type="idl" href="#dom-document-pictureinpictureenabled" id="ref-for-dom-document-pictureinpictureenabled-1">pictureInPictureEnabled</a></code> is <var>false</var>, reject <var>promise</var> with a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#notsupportederror">NotSupportedError</a></code> and abort these steps.</p>
+    <li data-md="">
+     <p>If <var>options</var> is not valid, reject <var>promise</var> with a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#exceptiondef-typeerror">TypeError</a></code> and abort
+these steps.</p>
+    <li data-md="">
+     <p>Let <var>video</var> be the requested video.</p>
+    <li data-md="">
+     <p>Run the <a data-link-type="dfn" href="#request-picture-in-picture-algorithm" id="ref-for-request-picture-in-picture-algorithm-1">request Picture In Picture algorithm</a> with <var>video</var> and <var>options</var>.</p>
+    <li data-md="">
+     <p>If the previous step threw an exception, reject <var>promise</var> with that
+exception and abort these steps.</p>
+    <li data-md="">
+     <p>Set <code class="idl"><a data-link-type="idl" href="#dom-documentorshadowroot-pictureinpictureelement" id="ref-for-dom-documentorshadowroot-pictureinpictureelement-1">pictureInPictureElement</a></code> to <var>video</var>.</p>
+    <li data-md="">
+     <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">Queue a task</a> to <a data-link-type="dfn">fire a simple event</a> with the name <code class="idl"><a data-link-type="idl" href="#eventdef-htmlvideoelement-enterpictureinpicture" id="ref-for-eventdef-htmlvideoelement-enterpictureinpicture-1">enterpictureinpicture</a></code> at the <var>video</var>. The event MUST not
+bubble, MUST not be cancelable, and has no default action.</p>
+    <li data-md="">
+     <p>Return <var>promise</var>.</p>
+   </ol>
+   <p class="note" role="note"><span>Note:</span> When a video is played in Picture in Picture, the states should
+transition as if it was played inline. That means that the events should fire
+at the same time, calling methods should have the same behaviour, etc. However,
+the user agent might transition out of Picture in Picture when the video
+element enters a state that is considered not compatible with Picture in
+Picture.</p>
+   <p>When the <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="request-picture-in-picture-algorithm">request Picture In Picture algorithm</dfn> with <var>video</var> and <var>options</var> is invoked, the user agent MUST run the following steps:</p>
+   <ol>
+    <li data-md="">
+     <p>If the algorithm is not <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/interaction.html#triggered-by-user-activation">triggered by user activation</a>, throw a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#securityerror">SecurityError</a></code> and abort these steps.</p>
+    <li data-md="">
+     <p>Let <var>pipWindow</var> be the Picture In Picture window that consistently stays
+above most other windows.</p>
+    <li data-md="">
+     <p>Let <var>pipVideo</var> be the video contained in the <var>pipWindow</var>.</p>
+    <li data-md="">
+     <p>If a <var>pipWindow</var> is not already created, create one.</p>
+    <li data-md="">
+     <p>If one can’t be created, throw a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#unknownerror">UnknownError</a></code> and abort these steps.</p>
+    <li data-md="">
+     <p>Apply <var>options</var> <code class="idl"><a data-link-type="idl" href="#dom-pictureinpictureoptions-width" id="ref-for-dom-pictureinpictureoptions-width-1">width</a></code>, <code class="idl"><a data-link-type="idl" href="#dom-pictureinpictureoptions-height" id="ref-for-dom-pictureinpictureoptions-height-1">height</a></code>, <code class="idl"><a data-link-type="idl" href="#dom-pictureinpictureoptions-top" id="ref-for-dom-pictureinpictureoptions-top-1">top</a></code>, and <code class="idl"><a data-link-type="idl" href="#dom-pictureinpictureoptions-start" id="ref-for-dom-pictureinpictureoptions-start-1">start</a></code> to the <var>pipWindow</var> dimensions and position. If some <var>options</var> can’t
+be applied, it SHOULD apply latest ones that were successfully set if any.</p>
+    <li data-md="">
+     <p>Render <var>video</var> frames in the <var>pipVideo</var>.</p>
+   </ol>
+   <p class="note" role="note"><span>Note:</span> It is recommended that the <var>video</var> frames are not rendered in the page and
+in the <var>pipVideo</var> at the same time but if they are, they must be kept in sync.</p>
+   <h3 class="heading settled" data-level="2.3" id="document-extension"><span class="secno">2.3. </span><span class="content"><code>Document</code> and <code>DocumentOrShadowRoot</code> extension</span><a class="self-link" href="#document-extension"></a></h3>
+<pre class="idl highlight def"><span class="kt">partial</span> <span class="kt">interface</span> <a class="nv idl-code" data-link-type="interface" href="https://html.spec.whatwg.org/multipage/dom.html#document">Document</a> {
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean"><span class="kt">boolean</span></a> <dfn class="nv dfn-paneled idl-code" data-dfn-for="Document" data-dfn-type="attribute" data-export="" data-readonly="" data-type="boolean" id="dom-document-pictureinpictureenabled"><code>pictureInPictureEnabled</code></dfn>;
+
+  <span class="kt">Promise</span>&lt;<span class="kt">void</span>> <dfn class="nv dfn-paneled idl-code" data-dfn-for="Document" data-dfn-type="method" data-export="" data-lt="exitPictureInPicture()" id="dom-document-exitpictureinpicture"><code>exitPictureInPicture</code></dfn>();
+};
+</pre>
+<pre class="idl highlight def"><span class="kt">partial</span> <span class="kt">interface</span> <a class="nv idl-code" data-link-type="interface" href="https://dom.spec.whatwg.org/#documentorshadowroot">DocumentOrShadowRoot</a> {
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#element">Element</a>? <dfn class="nv dfn-paneled idl-code" data-dfn-for="DocumentOrShadowRoot" data-dfn-type="attribute" data-export="" data-readonly="" data-type="Element?" id="dom-documentorshadowroot-pictureinpictureelement"><code>pictureInPictureElement</code></dfn>;
+};
+</pre>
+   <p>The <code class="idl"><a data-link-type="idl" href="#dom-document-pictureinpictureenabled" id="ref-for-dom-document-pictureinpictureenabled-2">pictureInPictureEnabled</a></code> attribute’s getter must return
+true if the <a data-link-type="dfn" href="https://dom.spec.whatwg.org/#context-object">context object</a> is <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/embedded-content.html#allowed-to-use">allowed to use</a> the feature
+indicated by attribute name <code>allowpictureinpicture</code> and <a data-link-type="dfn" href="#picture-in-picture-is-supported" id="ref-for-picture-in-picture-is-supported-1">Picture
+In Picture is supported</a>, and false otherwise.</p>
+   <p><dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="picture-in-picture-is-supported">Picture In Picture is supported</dfn> if there is no
+previously-established user preference, security risk, or platform limitation.</p>
+   <p>The <code class="idl"><a data-link-type="idl" href="#dom-document-exitpictureinpicture" id="ref-for-dom-document-exitpictureinpicture-1">exitPictureInPicture()</a></code> method, when invoked, MUST
+return <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#a-new-promise">a new promise</a> <var>promise</var> and run the following steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in
+parallel</a>:</p>
+   <ol>
+    <li data-md="">
+     <p>If <code class="idl"><a data-link-type="idl" href="#dom-document-pictureinpictureenabled" id="ref-for-dom-document-pictureinpictureenabled-3">pictureInPictureEnabled</a></code> is <var>false</var>, reject <var>promise</var> with a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#notsupportederror">NotSupportedError</a></code> and abort these steps.</p>
+    <li data-md="">
+     <p>Run the <a data-link-type="dfn" href="#exit-picture-in-picture-algorithm" id="ref-for-exit-picture-in-picture-algorithm-1">exit Picture In Picture algorithm</a>.</p>
+    <li data-md="">
+     <p>If the previous step threw an exception, reject <var>promise</var> with that
+exception and abort these steps.</p>
+    <li data-md="">
+     <p>Unset <code class="idl"><a data-link-type="idl" href="#dom-documentorshadowroot-pictureinpictureelement" id="ref-for-dom-documentorshadowroot-pictureinpictureelement-2">pictureInPictureElement</a></code>.</p>
+    <li data-md="">
+     <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">Queue a task</a> to <a data-link-type="dfn">fire a simple event</a> with the name <code class="idl"><a data-link-type="idl" href="#eventdef-htmlvideoelement-leavepictureinpicture" id="ref-for-eventdef-htmlvideoelement-leavepictureinpicture-1">leavepictureinpicture</a></code> at the <var>video</var>. The event MUST not
+bubble, MUST not be cancelable, and has no default action.</p>
+    <li data-md="">
+     <p>Return <var>promise</var>.</p>
+   </ol>
+   <p>When the <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="exit-picture-in-picture-algorithm">exit Picture In Picture algorithm</dfn> is invoked,
+the user agent MUST run the following steps:</p>
+   <ol>
+    <li data-md="">
+     <p>Let <var>pipWindow</var> be the current Picture In Picture window.</p>
+    <li data-md="">
+     <p>Let <var>pipVideo</var> be the video contained in the <var>pipWindow</var>.</p>
+    <li data-md="">
+     <p>Let <var>video</var> be the source video of <var>pipVideo</var> frames.</p>
+    <li data-md="">
+     <p>Close <var>pipWindow</var>.</p>
+    <li data-md="">
+     <p>If <var>pipWindow</var> can’t be closed, throw a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#unknownerror">UnknownError</a></code> and abort these steps.</p>
+    <li data-md="">
+     <p>Render <var>pipVideo</var> frames in the <var>video</var>.</p>
+   </ol>
+   <h3 class="heading settled" data-level="2.4" id="event-types"><span class="secno">2.4. </span><span class="content">Event types</span><a class="self-link" href="#event-types"></a></h3>
+   <dl>
+    <dt><dfn class="dfn-paneled idl-code" data-dfn-for="HTMLVideoElement" data-dfn-type="event" data-export="" id="eventdef-htmlvideoelement-enterpictureinpicture"><code><code>enterpictureinpicture</code></code></dfn>
+    <dd> Fired on a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/embedded-content.html#htmlvideoelement">HTMLVideoElement</a></code> when it enters Picture In Picture. 
+    <dt><dfn class="dfn-paneled idl-code" data-dfn-for="HTMLVideoElement" data-dfn-type="event" data-export="" id="eventdef-htmlvideoelement-leavepictureinpicture"><code><code>leavepictureinpicture</code></code></dfn>
+    <dd> Fired on a <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/embedded-content.html#htmlvideoelement">HTMLVideoElement</a></code> when it leaves Picture In Picture. 
+   </dl>
+   <h2 class="heading settled" data-level="3" id="integration"><span class="secno">3. </span><span class="content">Integration</span><a class="self-link" href="#integration"></a></h2>
+   <p>User agents are encouraged to implement native media Picture In Picture
+controls in terms of <code class="idl"><a data-link-type="idl" href="#dom-htmlvideoelement-requestpictureinpicture" id="ref-for-dom-htmlvideoelement-requestpictureinpicture-2">requestPictureInPicture()</a></code> and <code class="idl"><a data-link-type="idl" href="#dom-document-exitpictureinpicture" id="ref-for-dom-document-exitpictureinpicture-2">exitPictureInPicture()</a></code>.</p>
+   <h3 class="heading settled" data-level="3.1" id="remote-playback"><span class="secno">3.1. </span><span class="content">Interaction with remote playback</span><a class="self-link" href="#remote-playback"></a></h3>
+   <p>The <a data-link-type="dfn">Remote Playback specification</a> defines a <a data-link-type="dfn">local playback device</a> and a <a data-link-type="dfn">local playback state</a>. For the purpose of Picture in Picture, the
+playback is local and regardless of whether it is played in page or in Picture
+in Picture.</p>
+   <h3 class="heading settled" data-level="3.2" id="one-pip-window"><span class="secno">3.2. </span><span class="content">One Picture in Picture window</span><a class="self-link" href="#one-pip-window"></a></h3>
+   <p>Operating systems with a Picture In Picture API usually restricts Picture In
+Picture to only one window.  Whether only one window is allowed in Picture In
+Picture will be left to the implementation and the platform. However, because
+of the one Picture In Picture window limitation, the specification assumes that
+a given <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/dom.html#document">Document</a></code> can only have one Picture In Picture window.</p>
+   <p>What happens when there is a Picture In Picture request while a window is
+already in Picture In Picture will be left as an implementation details: the
+current Picture In Picture window could be closed, the Picture In Picture
+request could be rejected or even two Picture In Picture windows can be
+created. Regardless, the User Agent will have to fire the appropriate events
+in order to notify the website of the Picture In Picture status changes.</p>
+   <h3 class="heading settled" data-level="3.3" id="feature-policy"><span class="secno">3.3. </span><span class="content">Feature Policy</span><a class="self-link" href="#feature-policy"></a></h3>
+   <p>This specification defines a <a data-link-type="dfn" href="https://wicg.github.io/feature-policy/#feature">feature</a> that controls whether <code class="idl"><a data-link-type="idl" href="#dom-document-pictureinpictureenabled" id="ref-for-dom-document-pictureinpictureenabled-4">pictureInPictureEnabled</a></code> is <var>true</var> or <var>false</var>.</p>
+   <p>The <a data-link-type="dfn" href="https://wicg.github.io/feature-policy/#feature-name">feature name</a> for this feature is <code>"picture-in-picture"</code>.</p>
+   <p>The <a data-link-type="dfn" href="https://wicg.github.io/feature-policy/#default-allowlist">default allowlist</a> for this feature is <code>["self"]</code>.</p>
+  </main>
+  <div data-fill-with="conformance">
+   <h2 class="no-ref no-num heading settled" id="conformance"><span class="content"> Conformance</span><a class="self-link" href="#conformance"></a></h2>
+   <p> Conformance requirements are expressed with a combination of descriptive assertions and RFC 2119 terminology.
+            The key words “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”, “SHOULD NOT”, “RECOMMENDED”, “MAY”, and “OPTIONAL”
+            in the normative parts of this document
+            are to be interpreted as described in RFC 2119.
+            However, for readability,
+            these words do not appear in all uppercase letters in this specification. </p>
+   <p> All of the text of this specification is normative
+            except sections explicitly marked as non-normative, examples, and notes. <a data-link-type="biblio" href="#biblio-rfc2119">[RFC2119]</a> </p>
+   <p> Examples in this specification are introduced with the words “for example”
+            or are set apart from the normative text with <code>class="example"</code>, like this: </p>
+   <div class="example" id="example-example"><a class="self-link" href="#example-example"></a> This is an example of an informative example. </div>
+   <p> Informative notes begin with the word “Note”
+            and are set apart from the normative text with <code>class="note"</code>, like this: </p>
+   <p class="note" role="note"> Note, this is an informative note. </p>
+  </div>
+<script>
+(function() {
+  "use strict";
+  var collapseSidebarText = '<span aria-hidden="true">←</span> '
+                          + '<span>Collapse Sidebar</span>';
+  var expandSidebarText   = '<span aria-hidden="true">→</span> '
+                          + '<span>Pop Out Sidebar</span>';
+  var tocJumpText         = '<span aria-hidden="true">↑</span> '
+                          + '<span>Jump to Table of Contents</span>';
+
+  var sidebarMedia = window.matchMedia('screen and (min-width: 78em)');
+  var autoToggle   = function(e){ toggleSidebar(e.matches) };
+  if(sidebarMedia.addListener) {
+    sidebarMedia.addListener(autoToggle);
+  }
+
+  function toggleSidebar(on) {
+    if (on == undefined) {
+      on = !document.body.classList.contains('toc-sidebar');
+    }
+
+    /* Don’t scroll to compensate for the ToC if we’re above it already. */
+    var headY = 0;
+    var head = document.querySelector('.head');
+    if (head) {
+      // terrible approx of "top of ToC"
+      headY += head.offsetTop + head.offsetHeight;
+    }
+    var skipScroll = window.scrollY < headY;
+
+    var toggle = document.getElementById('toc-toggle');
+    var tocNav = document.getElementById('toc');
+    if (on) {
+      var tocHeight = tocNav.offsetHeight;
+      document.body.classList.add('toc-sidebar');
+      document.body.classList.remove('toc-inline');
+      toggle.innerHTML = collapseSidebarText;
+      if (!skipScroll) {
+        window.scrollBy(0, 0 - tocHeight);
+      }
+      tocNav.focus();
+      sidebarMedia.addListener(autoToggle); // auto-collapse when out of room
+    }
+    else {
+      document.body.classList.add('toc-inline');
+      document.body.classList.remove('toc-sidebar');
+      toggle.innerHTML = expandSidebarText;
+      if (!skipScroll) {
+        window.scrollBy(0, tocNav.offsetHeight);
+      }
+      if (toggle.matches(':hover')) {
+        /* Unfocus button when not using keyboard navigation,
+           because I don’t know where else to send the focus. */
+        toggle.blur();
+      }
+    }
+  }
+
+  function createSidebarToggle() {
+    /* Create the sidebar toggle in JS; it shouldn’t exist when JS is off. */
+    var toggle = document.createElement('a');
+      /* This should probably be a button, but appearance isn’t standards-track.*/
+    toggle.id = 'toc-toggle';
+    toggle.class = 'toc-toggle';
+    toggle.href = '#toc';
+    toggle.innerHTML = collapseSidebarText;
+
+    sidebarMedia.addListener(autoToggle);
+    var toggler = function(e) {
+      e.preventDefault();
+      sidebarMedia.removeListener(autoToggle); // persist explicit off states
+      toggleSidebar();
+      return false;
+    }
+    toggle.addEventListener('click', toggler, false);
+
+
+    /* Get <nav id=toc-nav>, or make it if we don’t have one. */
+    var tocNav = document.getElementById('toc-nav');
+    if (!tocNav) {
+      tocNav = document.createElement('p');
+      tocNav.id = 'toc-nav';
+      /* Prepend for better keyboard navigation */
+      document.body.insertBefore(tocNav, document.body.firstChild);
+    }
+    /* While we’re at it, make sure we have a Jump to Toc link. */
+    var tocJump = document.getElementById('toc-jump');
+    if (!tocJump) {
+      tocJump = document.createElement('a');
+      tocJump.id = 'toc-jump';
+      tocJump.href = '#toc';
+      tocJump.innerHTML = tocJumpText;
+      tocNav.appendChild(tocJump);
+    }
+
+    tocNav.appendChild(toggle);
+  }
+
+  var toc = document.getElementById('toc');
+  if (toc) {
+    createSidebarToggle();
+    toggleSidebar(sidebarMedia.matches);
+
+    /* If the sidebar has been manually opened and is currently overlaying the text
+       (window too small for the MQ to add the margin to body),
+       then auto-close the sidebar once you click on something in there. */
+    toc.addEventListener('click', function(e) {
+      if(e.target.tagName.toLowerCase() == "a" && document.body.classList.contains('toc-sidebar') && !sidebarMedia.matches) {
+        toggleSidebar(false);
+      }
+    }, false);
+  }
+  else {
+    console.warn("Can’t find Table of Contents. Please use <nav id='toc'> around the ToC.");
+  }
+
+  /* Wrap tables in case they overflow */
+  var tables = document.querySelectorAll(':not(.overlarge) > table.data, :not(.overlarge) > table.index');
+  var numTables = tables.length;
+  for (var i = 0; i < numTables; i++) {
+    var table = tables[i];
+    var wrapper = document.createElement('div');
+    wrapper.className = 'overlarge';
+    table.parentNode.insertBefore(wrapper, table);
+    wrapper.appendChild(table);
+  }
+
+})();
+</script>
+  <h2 class="no-num no-ref heading settled" id="index"><span class="content">Index</span><a class="self-link" href="#index"></a></h2>
+  <h3 class="no-num no-ref heading settled" id="index-defined-here"><span class="content">Terms defined by this specification</span><a class="self-link" href="#index-defined-here"></a></h3>
+  <ul class="index">
+   <li><a href="#eventdef-htmlvideoelement-enterpictureinpicture">enterpictureinpicture</a><span>, in §2.4</span>
+   <li><a href="#dom-document-exitpictureinpicture">exitPictureInPicture()</a><span>, in §2.3</span>
+   <li><a href="#exit-picture-in-picture-algorithm">exit Picture In Picture algorithm</a><span>, in §2.3</span>
+   <li><a href="#dom-pictureinpictureoptions-height">height</a><span>, in §2.2</span>
+   <li><a href="#eventdef-htmlvideoelement-leavepictureinpicture">leavepictureinpicture</a><span>, in §2.4</span>
+   <li><a href="#dom-htmlvideoelement-onenterpictureinpicture">onenterpictureinpicture</a><span>, in §2.2</span>
+   <li><a href="#dom-htmlvideoelement-onleavepictureinpicture">onleavepictureinpicture</a><span>, in §2.2</span>
+   <li><a href="#dom-documentorshadowroot-pictureinpictureelement">pictureInPictureElement</a><span>, in §2.3</span>
+   <li><a href="#dom-document-pictureinpictureenabled">pictureInPictureEnabled</a><span>, in §2.3</span>
+   <li><a href="#picture-in-picture-is-supported">Picture In Picture is supported</a><span>, in §2.3</span>
+   <li><a href="#dictdef-pictureinpictureoptions">PictureInPictureOptions</a><span>, in §2.2</span>
+   <li><a href="#dom-htmlvideoelement-requestpictureinpicture">requestPictureInPicture()</a><span>, in §2.2</span>
+   <li><a href="#request-picture-in-picture-algorithm">request Picture In Picture algorithm</a><span>, in §2.2</span>
+   <li><a href="#dom-htmlvideoelement-requestpictureinpicture">requestPictureInPicture(options)</a><span>, in §2.2</span>
+   <li><a href="#dom-pictureinpictureoptions-start">start</a><span>, in §2.2</span>
+   <li><a href="#dom-pictureinpictureoptions-top">top</a><span>, in §2.2</span>
+   <li><a href="#dom-pictureinpictureoptions-width">width</a><span>, in §2.2</span>
+  </ul>
+  <h3 class="no-num no-ref heading settled" id="index-defined-elsewhere"><span class="content">Terms defined by reference</span><a class="self-link" href="#index-defined-elsewhere"></a></h3>
+  <ul class="index">
+   <li>
+    <a data-link-type="biblio">[DOM]</a> defines the following terms:
+    <ul>
+     <li><a href="https://dom.spec.whatwg.org/#documentorshadowroot">DocumentOrShadowRoot</a>
+     <li><a href="https://dom.spec.whatwg.org/#element">Element</a>
+     <li><a href="https://dom.spec.whatwg.org/#context-object">context object</a>
+    </ul>
+   <li>
+    <a data-link-type="biblio">[feature policy]</a> defines the following terms:
+    <ul>
+     <li><a href="https://wicg.github.io/feature-policy/#default-allowlist">default allowlist</a>
+     <li><a href="https://wicg.github.io/feature-policy/#feature">feature</a>
+     <li><a href="https://wicg.github.io/feature-policy/#feature-name">feature name</a>
+    </ul>
+   <li>
+    <a data-link-type="biblio">[HTML]</a> defines the following terms:
+    <ul>
+     <li><a href="https://html.spec.whatwg.org/multipage/dom.html#document">Document</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler">EventHandler</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#htmlvideoelement">HTMLVideoElement</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/embedded-content.html#allowed-to-use">allowed to use</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue a task</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/interaction.html#triggered-by-user-activation">triggered by user activation</a>
+    </ul>
+   <li>
+    <a data-link-type="biblio">[promises-guide]</a> defines the following terms:
+    <ul>
+     <li><a href="https://www.w3.org/2001/tag/doc/promises-guide/#a-new-promise">a new promise</a>
+    </ul>
+   <li>
+    <a data-link-type="biblio">[WebIDL]</a> defines the following terms:
+    <ul>
+     <li><a href="https://heycam.github.io/webidl/#notsupportederror">NotSupportedError</a>
+     <li><a href="https://heycam.github.io/webidl/#securityerror">SecurityError</a>
+     <li><a href="https://heycam.github.io/webidl/#exceptiondef-typeerror">TypeError</a>
+     <li><a href="https://heycam.github.io/webidl/#unknownerror">UnknownError</a>
+     <li><a href="https://heycam.github.io/webidl/#idl-boolean">boolean</a>
+     <li><a href="https://heycam.github.io/webidl/#idl-unsigned-long">unsigned long</a>
+    </ul>
+  </ul>
+  <h2 class="no-num no-ref heading settled" id="references"><span class="content">References</span><a class="self-link" href="#references"></a></h2>
+  <h3 class="no-num no-ref heading settled" id="normative"><span class="content">Normative References</span><a class="self-link" href="#normative"></a></h3>
+  <dl>
+   <dt id="biblio-dom">[DOM]
+   <dd>Anne van Kesteren. <a href="https://dom.spec.whatwg.org/">DOM Standard</a>. Living Standard. URL: <a href="https://dom.spec.whatwg.org/">https://dom.spec.whatwg.org/</a>
+   <dt id="biblio-html">[HTML]
+   <dd>Anne van Kesteren; et al. <a href="https://html.spec.whatwg.org/multipage/">HTML Standard</a>. Living Standard. URL: <a href="https://html.spec.whatwg.org/multipage/">https://html.spec.whatwg.org/multipage/</a>
+   <dt id="biblio-promises-guide">[PROMISES-GUIDE]
+   <dd>Domenic Denicola. <a href="https://www.w3.org/2001/tag/doc/promises-guide">Writing Promise-Using Specifications</a>. 16 February 2016. Finding of the W3C TAG. URL: <a href="https://www.w3.org/2001/tag/doc/promises-guide">https://www.w3.org/2001/tag/doc/promises-guide</a>
+   <dt id="biblio-rfc2119">[RFC2119]
+   <dd>S. Bradner. <a href="https://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a>. March 1997. Best Current Practice. URL: <a href="https://tools.ietf.org/html/rfc2119">https://tools.ietf.org/html/rfc2119</a>
+   <dt id="biblio-webidl">[WebIDL]
+   <dd>Cameron McCormack; Boris Zbarsky; Tobie Langel. <a href="https://heycam.github.io/webidl/">Web IDL</a>. URL: <a href="https://heycam.github.io/webidl/">https://heycam.github.io/webidl/</a>
+  </dl>
+  <h2 class="no-num no-ref heading settled" id="idl-index"><span class="content">IDL Index</span><a class="self-link" href="#idl-index"></a></h2>
+<pre class="idl highlight def"><span class="kt"><span class="kt">dictionary</span></span> <a class="nv" href="#dictdef-pictureinpictureoptions"><code><span class="nv">PictureInPictureOptions</span></code></a> {
+  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long"><span class="kt"><span class="kt">unsigned</span></span> <span class="kt"><span class="kt">long</span></span></a> <a class="nv" data-type="unsigned long " href="#dom-pictureinpictureoptions-width"><code><span class="nv">width</span></code></a>;
+  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long"><span class="kt"><span class="kt">unsigned</span></span> <span class="kt"><span class="kt">long</span></span></a> <a class="nv" data-type="unsigned long " href="#dom-pictureinpictureoptions-height"><code><span class="nv">height</span></code></a>;
+  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long"><span class="kt"><span class="kt">unsigned</span></span> <span class="kt"><span class="kt">long</span></span></a> <a class="nv" data-type="unsigned long " href="#dom-pictureinpictureoptions-top"><code><span class="nv">top</span></code></a>;
+  <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unsigned-long"><span class="kt"><span class="kt">unsigned</span></span> <span class="kt"><span class="kt">long</span></span></a> <a class="nv" data-type="unsigned long " href="#dom-pictureinpictureoptions-start"><code><span class="nv">start</span></code></a>;
+};
+
+<span class="kt"><span class="kt">partial</span></span> <span class="kt"><span class="kt">interface</span></span> <a class="nv idl-code" data-link-type="interface" href="https://html.spec.whatwg.org/multipage/embedded-content.html#htmlvideoelement"><span class="nv">HTMLVideoElement</span></a> {
+  <span class="kt"><span class="kt">Promise</span></span>&lt;<span class="kt"><span class="kt">void</span></span>> <a class="nv" href="#dom-htmlvideoelement-requestpictureinpicture"><code><span class="nv">requestPictureInPicture</span></code></a>(<span class="kt"><span class="kt">optional</span></span> <a class="n" data-link-type="idl-name" href="#dictdef-pictureinpictureoptions"><span class="n">PictureInPictureOptions</span></a> <a class="nv" href="#dom-htmlvideoelement-requestpictureinpicture-options-options"><code><span class="nv">options</span></code></a>);
+
+  <span class="kt"><span class="kt">attribute</span></span> <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler"><span class="n">EventHandler</span></a> <a class="nv" data-type="EventHandler" href="#dom-htmlvideoelement-onenterpictureinpicture"><code><span class="nv">onenterpictureinpicture</span></code></a>;
+  <span class="kt"><span class="kt">attribute</span></span> <a class="n" data-link-type="idl-name" href="https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler"><span class="n">EventHandler</span></a> <a class="nv" data-type="EventHandler" href="#dom-htmlvideoelement-onleavepictureinpicture"><code><span class="nv">onleavepictureinpicture</span></code></a>;
+};
+
+<span class="kt"><span class="kt">partial</span></span> <span class="kt"><span class="kt">interface</span></span> <a class="nv idl-code" data-link-type="interface" href="https://html.spec.whatwg.org/multipage/dom.html#document"><span class="nv">Document</span></a> {
+  <span class="kt"><span class="kt">readonly</span></span> <span class="kt"><span class="kt">attribute</span></span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-boolean"><span class="kt"><span class="kt">boolean</span></span></a> <a class="nv" data-readonly="" data-type="boolean" href="#dom-document-pictureinpictureenabled"><code><span class="nv">pictureInPictureEnabled</span></code></a>;
+
+  <span class="kt"><span class="kt">Promise</span></span>&lt;<span class="kt"><span class="kt">void</span></span>> <a class="nv" href="#dom-document-exitpictureinpicture"><code><span class="nv">exitPictureInPicture</span></code></a>();
+};
+
+<span class="kt"><span class="kt">partial</span></span> <span class="kt"><span class="kt">interface</span></span> <a class="nv idl-code" data-link-type="interface" href="https://dom.spec.whatwg.org/#documentorshadowroot"><span class="nv">DocumentOrShadowRoot</span></a> {
+  <span class="kt"><span class="kt">readonly</span></span> <span class="kt"><span class="kt">attribute</span></span> <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#element"><span class="n">Element</span></a>? <a class="nv" data-readonly="" data-type="Element?" href="#dom-documentorshadowroot-pictureinpictureelement"><code><span class="nv">pictureInPictureElement</span></code></a>;
+};
+
+</pre>
+  <aside class="dfn-panel" data-for="dictdef-pictureinpictureoptions">
+   <b><a href="#dictdef-pictureinpictureoptions">#dictdef-pictureinpictureoptions</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dictdef-pictureinpictureoptions-1">2.2. HTMLVideoElement extension</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-pictureinpictureoptions-width">
+   <b><a href="#dom-pictureinpictureoptions-width">#dom-pictureinpictureoptions-width</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-pictureinpictureoptions-width-1">2.2. HTMLVideoElement extension</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-pictureinpictureoptions-height">
+   <b><a href="#dom-pictureinpictureoptions-height">#dom-pictureinpictureoptions-height</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-pictureinpictureoptions-height-1">2.2. HTMLVideoElement extension</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-pictureinpictureoptions-top">
+   <b><a href="#dom-pictureinpictureoptions-top">#dom-pictureinpictureoptions-top</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-pictureinpictureoptions-top-1">2.2. HTMLVideoElement extension</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-pictureinpictureoptions-start">
+   <b><a href="#dom-pictureinpictureoptions-start">#dom-pictureinpictureoptions-start</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-pictureinpictureoptions-start-1">2.2. HTMLVideoElement extension</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-htmlvideoelement-requestpictureinpicture">
+   <b><a href="#dom-htmlvideoelement-requestpictureinpicture">#dom-htmlvideoelement-requestpictureinpicture</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-htmlvideoelement-requestpictureinpicture-1">2.2. HTMLVideoElement extension</a>
+    <li><a href="#ref-for-dom-htmlvideoelement-requestpictureinpicture-2">3. Integration</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="request-picture-in-picture-algorithm">
+   <b><a href="#request-picture-in-picture-algorithm">#request-picture-in-picture-algorithm</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-request-picture-in-picture-algorithm-1">2.2. HTMLVideoElement extension</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-document-pictureinpictureenabled">
+   <b><a href="#dom-document-pictureinpictureenabled">#dom-document-pictureinpictureenabled</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-document-pictureinpictureenabled-1">2.2. HTMLVideoElement extension</a>
+    <li><a href="#ref-for-dom-document-pictureinpictureenabled-2">2.3. Document and DocumentOrShadowRoot extension</a> <a href="#ref-for-dom-document-pictureinpictureenabled-3">(2)</a>
+    <li><a href="#ref-for-dom-document-pictureinpictureenabled-4">3.3. Feature Policy</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-document-exitpictureinpicture">
+   <b><a href="#dom-document-exitpictureinpicture">#dom-document-exitpictureinpicture</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-document-exitpictureinpicture-1">2.3. Document and DocumentOrShadowRoot extension</a>
+    <li><a href="#ref-for-dom-document-exitpictureinpicture-2">3. Integration</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="dom-documentorshadowroot-pictureinpictureelement">
+   <b><a href="#dom-documentorshadowroot-pictureinpictureelement">#dom-documentorshadowroot-pictureinpictureelement</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-dom-documentorshadowroot-pictureinpictureelement-1">2.2. HTMLVideoElement extension</a>
+    <li><a href="#ref-for-dom-documentorshadowroot-pictureinpictureelement-2">2.3. Document and DocumentOrShadowRoot extension</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="picture-in-picture-is-supported">
+   <b><a href="#picture-in-picture-is-supported">#picture-in-picture-is-supported</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-picture-in-picture-is-supported-1">2.3. Document and DocumentOrShadowRoot extension</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="exit-picture-in-picture-algorithm">
+   <b><a href="#exit-picture-in-picture-algorithm">#exit-picture-in-picture-algorithm</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-exit-picture-in-picture-algorithm-1">2.3. Document and DocumentOrShadowRoot extension</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="eventdef-htmlvideoelement-enterpictureinpicture">
+   <b><a href="#eventdef-htmlvideoelement-enterpictureinpicture">#eventdef-htmlvideoelement-enterpictureinpicture</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-eventdef-htmlvideoelement-enterpictureinpicture-1">2.2. HTMLVideoElement extension</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="eventdef-htmlvideoelement-leavepictureinpicture">
+   <b><a href="#eventdef-htmlvideoelement-leavepictureinpicture">#eventdef-htmlvideoelement-leavepictureinpicture</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-eventdef-htmlvideoelement-leavepictureinpicture-1">2.3. Document and DocumentOrShadowRoot extension</a>
+   </ul>
+  </aside>
+<script>/* script-dfn-panel */
+
+        document.body.addEventListener("click", function(e) {
+            var queryAll = function(sel) { return [].slice.call(document.querySelectorAll(sel)); }
+            // Find the dfn element or panel, if any, that was clicked on.
+            var el = e.target;
+            var target;
+            var hitALink = false;
+            while(el.parentElement) {
+                if(el.tagName == "A") {
+                    // Clicking on a link in a <dfn> shouldn't summon the panel
+                    hitALink = true;
+                }
+                if(el.classList.contains("dfn-paneled")) {
+                    target = "dfn";
+                    break;
+                }
+                if(el.classList.contains("dfn-panel")) {
+                    target = "dfn-panel";
+                    break;
+                }
+                el = el.parentElement;
+            }
+            if(target != "dfn-panel") {
+                // Turn off any currently "on" or "activated" panels.
+                queryAll(".dfn-panel.on, .dfn-panel.activated").forEach(function(el){
+                    el.classList.remove("on");
+                    el.classList.remove("activated");
+                });
+            }
+            if(target == "dfn" && !hitALink) {
+                // open the panel
+                var dfnPanel = document.querySelector(".dfn-panel[data-for='" + el.id + "']");
+                if(dfnPanel) {
+                    console.log(dfnPanel);
+                    dfnPanel.classList.add("on");
+                    var rect = el.getBoundingClientRect();
+                    dfnPanel.style.left = window.scrollX + rect.right + 5 + "px";
+                    dfnPanel.style.top = window.scrollY + rect.top + "px";
+                    var panelRect = dfnPanel.getBoundingClientRect();
+                    var panelWidth = panelRect.right - panelRect.left;
+                    if(panelRect.right > document.body.scrollWidth && (rect.left - (panelWidth + 5)) > 0) {
+                        // Reposition, because the panel is overflowing
+                        dfnPanel.style.left = window.scrollX + rect.left - (panelWidth + 5) + "px";
+                    }
+                } else {
+                    console.log("Couldn't find .dfn-panel[data-for='" + el.id + "']");
+                }
+            } else if(target == "dfn-panel") {
+                // Switch it to "activated" state, which pins it.
+                el.classList.add("activated");
+                el.style.left = null;
+                el.style.top = null;
+            }
+
+        });
+        </script>


### PR DESCRIPTION
@mounirlamouri As promised, here it is.

FYI, bikeshed is not happy:

```
LINK ERROR: No 'dfn' refs found for 'htmlvideoelement'.
<a data-link-type="dfn" data-lt="HTMLVideoElement"><code>HTMLVideoElement</code></a>
LINK ERROR: No 'dfn' refs found for 'remote playback specification'.
<a data-link-type="dfn" data-lt="Remote Playback specification">Remote Playback specification</a>
LINK ERROR: No 'dfn' refs found for 'feature policy specification'.
<a data-link-type="dfn" data-lt="Feature Policy specification">Feature Policy specification</a>
```