### PR TITLE
Add favicon to spec

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4,6 +4,7 @@ Shortname: picture-in-picture
 Level: 1
 Status: ED
 ED: https://wicg.github.io/picture-in-picture
+Favicon: https://raw.githubusercontent.com/google/material-design-icons/master/action/2x_web/ic_picture_in_picture_alt_black_48dp.png
 Group: WICG
 Repository: wicg/picture-in-picture
 Editor: François Beaufort, Google, fbeaufort@google.com


### PR DESCRIPTION
Once https://github.com/tabatkins/bikeshed/pull/1177 is reviewed, merged, and live, this spec may have a proper "PiP" favicon.

![image](https://user-images.githubusercontent.com/634478/35555001-01632430-059e-11e8-9f5c-068e8b191448.png)
