### PR TITLE
Reorder error steps in request PiP

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -142,8 +142,8 @@ extensible.
 When the <dfn>request Picture-in-Picture algorithm</dfn> with |video| is
 invoked, the user agent MUST run the following steps:
 
-1. If {{pictureInPictureEnabled}} is |false|, throw a {{NotSupportedError}} and
-    abort these steps.
+1. If <a>Picture-in-Picture support</a> is <code>false</code>, throw a
+    {{NotSupportedError}} and abort these steps.
 2. If document is not allowed to use the <a>policy-controlled feature</a> named
     <code>"picture-in-picture"</code>, throw a {{SecurityError}} and abort these
     steps.
@@ -187,7 +187,7 @@ the user agent MUST run the following steps:
     {{leavepictureinpicture}} at the |video|. The event MUST not
     bubble, MUST not be cancelable, and has no default action.
 
-## Disable Picture-in-Picture
+## Disable Picture-in-Picture ## {#disable-pip}
 
 Some pages may want to disable Picture-in-Picture for a video element. To
 support this, a new {{disablePictureInPicture}} attribute is added to the list
@@ -277,12 +277,14 @@ partial interface Document {
 </pre>
 
 The {{pictureInPictureEnabled}} attribute's getter must return
-<code>true</code> if <a>Picture-in-Picture is supported</a> and the <a>context
-object</a> is <a>allowed to use</a> the feature indicated by attribute name
-<code>picture-in-picture</code>, and false otherwise.
+<code>true</code> if <a>Picture-in-Picture support</a> is <code>true</code> and
+the <a>context object</a> is <a>allowed to use</a> the feature indicated by
+attribute name <code>picture-in-picture</code>, and <code>false</code>
+otherwise.
 
-<dfn>Picture-in-Picture is supported</dfn> if there is no
-previously-established user preference, security risk, or platform limitation.
+<dfn>Picture-in-Picture support</dfn> is <code>true</code> if there is no
+previously-established user preference, security risk, or platform limitation,
+and <code>false</code> otherwise.
 
 The {{exitPictureInPicture()}} method, when invoked, MUST
 return <a>a new promise</a> |promise| and run the following steps <a>in

--- a/index.bs
+++ b/index.bs
@@ -142,11 +142,11 @@ extensible.
 When the <dfn>request Picture-in-Picture algorithm</dfn> with |video| is
 invoked, the user agent MUST run the following steps:
 
-1. If document is not allowed to use the <a>policy-controlled feature</a> named
+1. If {{pictureInPictureEnabled}} is |false|, throw a {{NotSupportedError}} and
+    abort these steps.
+2. If document is not allowed to use the <a>policy-controlled feature</a> named
     <code>"picture-in-picture"</code>, throw a {{SecurityError}} and abort these
     steps.
-2. If {{pictureInPictureEnabled}} is |false|, throw a {{NotSupportedError}} and
-    abort these steps.
 3. OPTIONALLY, if the {{disablePictureInPicture}} attribute is present on
     |video|, throw a {{InvalidStateError}} and abort these steps.
 4. If the algorithm is not <a>triggered by user activation</a>, throw a
@@ -277,9 +277,9 @@ partial interface Document {
 </pre>
 
 The {{pictureInPictureEnabled}} attribute's getter must return
-<code>true</code> if the <a>context object</a> is <a>allowed to use</a> the
-feature indicated by attribute name <code>picture-in-picture</code> and
-<a>Picture-in-Picture is supported</a>, and false otherwise.
+<code>true</code> if <a>Picture-in-Picture is supported</a> and the <a>context
+object</a> is <a>allowed to use</a> the feature indicated by attribute name
+<code>picture-in-picture</code>, and false otherwise.
 
 <dfn>Picture-in-Picture is supported</dfn> if there is no
 previously-established user preference, security risk, or platform limitation.

--- a/index.bs
+++ b/index.bs
@@ -283,7 +283,7 @@ attribute name <code>picture-in-picture</code>, and <code>false</code>
 otherwise.
 
 <dfn>Picture-in-Picture support</dfn> is <code>true</code> if there is no
-previously-established user preference, security risk, or platform limitation,
+previously-established user preference, restrictions, or platform limitation,
 and <code>false</code> otherwise.
 
 The {{exitPictureInPicture()}} method, when invoked, MUST


### PR DESCRIPTION
I'm reordering error steps so that web developer can take much easier some actions on this.

1. PiP is not enabled (you can't do anything)
2. Feature Policy prevents you to use PiP (update it if you can)
3. Video attribute prevents you to use PiP (remove it)
