### PR TITLE
Use unsigned long for pip Window dimensions

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -62,8 +62,8 @@ partial interface DocumentOrShadowRoot {
 };
 
 interface PictureInPictureWindow {
-  readonly attribute long width;
-  readonly attribute long height;
+  readonly attribute unsigned long width;
+  readonly attribute unsigned long height;
 
   attribute EventHandler onresize;
 };

--- a/index.bs
+++ b/index.bs
@@ -314,8 +314,8 @@ The {{pictureInPictureElement}} attribute's getter must run these steps:
 
 <pre class="idl">
 interface PictureInPictureWindow {
-  readonly attribute long width;
-  readonly attribute long height;
+  readonly attribute unsigned long width;
+  readonly attribute unsigned long height;
 
   attribute EventHandler onresize;
 };


### PR DESCRIPTION
According to https://www.w3.org/TR/WebIDL-1/#idl-long,

> The long type is a signed integer type that has values in the range [−2147483648, 2147483647].
> The unsigned long type is an unsigned integer type that has values in the range [0, 4294967295].

I believe we should use "unsigned long" then for pipWindow width and height. 