### PR TITLE
s/HTMLVideoElement/Element for pictureInPictureElement

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -58,7 +58,7 @@ partial interface Document {
 };
 
 partial interface DocumentOrShadowRoot {
-  readonly attribute HTMLVideoElement? pictureInPictureElement;
+  readonly attribute Element? pictureInPictureElement;
 };
 
 interface PictureInPictureWindow {

--- a/index.bs
+++ b/index.bs
@@ -307,11 +307,12 @@ partial interface DocumentOrShadowRoot {
 The {{pictureInPictureElement}} attribute's getter must run these steps:
 
 1. If the <a>context object</a> is a <a for=/>shadow root</a> and its
-    <a for=DocumentFragment>host</a> is not <a>connected</a>, then return null.
+    <a for=DocumentFragment>host</a> is not <a>connected</a>, return null and
+    abort these steps.
 2. Let |candidate| be the result of <a>retargeting</a> Picture-in-Picture
     element against the <a>context object</a>.
 3. If |candidate| and the <a>context object</a> are in the same <a>tree</a>,
-    then return |candidate|.
+    return |candidate| and abort these steps.
 4. Return null.
 
 ## <code>PictureInPictureWindow</code> ## {#picture-in-picture-window}

--- a/index.bs
+++ b/index.bs
@@ -300,7 +300,7 @@ parallel</a>:
 
 <pre class="idl">
 partial interface DocumentOrShadowRoot {
-  readonly attribute HTMLVideoElement? pictureInPictureElement;
+  readonly attribute Element? pictureInPictureElement;
 };
 </pre>
 
@@ -308,7 +308,11 @@ The {{pictureInPictureElement}} attribute's getter must run these steps:
 
 1. If the <a>context object</a> is a <a for=/>shadow root</a> and its
     <a for=DocumentFragment>host</a> is not <a>connected</a>, then return null.
-2. Return the Picture-in-Picture video element.
+2. Let |candidate| be the result of <a>retargeting</a> Picture-in-Picture
+    element against the <a>context object</a>.
+3. If |candidate| and the <a>context object</a> are in the same <a>tree</a>,
+    then return |candidate|.
+4. Return null.
 
 ## <code>PictureInPictureWindow</code> ## {#picture-in-picture-window}
 

--- a/index.bs
+++ b/index.bs
@@ -306,9 +306,8 @@ partial interface DocumentOrShadowRoot {
 
 The {{pictureInPictureElement}} attribute's getter must run these steps:
 
-1. If the <a>context object</a> is a <a for=/>shadow root</a> and its
-    <a for=DocumentFragment>host</a> is not <a>connected</a>, return null and
-    abort these steps.
+1. If the <a>context object</a> is not <a>connected</a>, return null and abort
+    these steps.
 2. Let |candidate| be the result of <a>retargeting</a> Picture-in-Picture
     element against the <a>context object</a>.
 3. If |candidate| and the <a>context object</a> are in the same <a>tree</a>,


### PR DESCRIPTION
It turns out `Element` is required for `pictureInPictureElement` as it needs to return shadow root elements as well.

This CL updates spec and explainer.