### PR TITLE
Update feature policy default allowlist to *

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -354,8 +354,10 @@ specification may allow PIP-ing arbitrary HTML content.
 ## Feature Policy ## {#feature-policy}
 
 This specification defines a <a>policy-controlled feature</a> that controls
-whether {{pictureInPictureEnabled}} is <code>true</code> or <code>false</code>.
+whether the <a>request Picture-in-Picture algorithm</a> may return a
+{{SecurityError}} and whether {{pictureInPictureEnabled}} is <code>true</code>
+or <code>false</code>.
 
 The <a>feature name</a> for this feature is <code>"picture-in-picture"</code>.
 
-The <a>default allowlist</a> for this feature is <code>["self"]</code>.
+The <a>default allowlist</a> for this feature is <code>*</code>.


### PR DESCRIPTION
This change allows Picture-in-Picture feature to be allowed by default to documents in child frames.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/picture-in-picture/pull/63.html" title="Last updated on Feb 20, 2018, 8:01 AM GMT (ed5c087)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/picture-in-picture/63/1c75942...ed5c087.html" title="Last updated on Feb 20, 2018, 8:01 AM GMT (ed5c087)">Diff</a>