### PR TITLE
Specify task source

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -28,6 +28,8 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/multipage/
             text: in parallel
         urlPrefix: interaction.html
             text: triggered by user activation
+        urlPrefix: media.html
+            text: media element event task source
 spec: Remote-Playback; urlPrefix: https://w3c.github.io/remote-playback/#dfn-
     type: dfn
         text: local playback device
@@ -347,6 +349,11 @@ the |state| is |opened|. Otherwise, it MUST return 0.
 :: Fired on a {{HTMLVideoElement}} when it leaves Picture-in-Picture.
 : <dfn event for="PictureInPictureWindow"><code>resize</code></dfn>
 :: Fired on a {{PictureInPictureWindow}} when it changes size.
+
+## Task source ## {#task-source}
+
+The <a>task source</a> for all the tasks queued in this specification is the
+<a>media element event task source</a> of the video element in question.
 
 # Security considerations # {#security-considerations}
 


### PR DESCRIPTION
As raised in https://chromium-review.googlesource.com/c/chromium/src/+/1025832/10/third_party/blink/renderer/modules/picture_in_picture/document_picture_in_picture.cc#48, this spec should set the task source used for entering and leaving Picture-in-Picture.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/picture-in-picture/pull/65.html" title="Last updated on May 3, 2018, 12:18 PM GMT (ac84628)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/picture-in-picture/65/57c1d46...ac84628.html" title="Last updated on May 3, 2018, 12:18 PM GMT (ac84628)">Diff</a>