### PR TITLE
Update explainer to include custom actions.

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -12,6 +12,9 @@ Many users want to continue consuming media while they interact with other conte
 
 *   A website wants to initiate a Picture-in-Picture experience from its own media or site controls.
 *   A website wants to be notified when the user initiates Picture-in-Picture on a video from the browser UI in order to update its UI.
+*   A website wants to inject an action into the Picture-in-Picture window by providing information used for the action in order to give its users control over the PiP’d media.
+*   A website wants to be notified when the user interacts with the action in order to handle it.
+
 
 ### For future considerations or candidates for first API
 
@@ -28,6 +31,7 @@ Many users want to continue consuming media while they interact with other conte
 *   The API will allow the website to trigger Picture-in-Picture via a user gesture on a video element.
 *   The API will allow the website to exit Picture-in-Picture.
 *   The API will allow the website to check if Picture-in-Picture can be triggered.
+*   The API will notify the website if a custom action is interacted with via user gesture.
 
 ### For future considerations or candidates for first API
 
@@ -43,9 +47,12 @@ The proposed API is very similar to the Fullscreen API as they have similar prop
 partial interface HTMLVideoElement {
   Promise<PictureInPictureWindow> requestPictureInPicture();
 
+  Promise<void> setPictureInPictureControls(FrozenArray<CustomActionMetadata> action);
+
   // On the fullscreen API, they live on the Document.
   attribute EventHandler onenterpictureinpicture;
   attribute EventHandler onleavepictureinpicture;
+  attribute EventHandler pictureinpicturecontrolsclick;
 
   [CEReactions]
   attribute boolean disablePictureInPicture;
@@ -67,6 +74,18 @@ interface PictureInPictureWindow {
 
   attribute EventHandler onresize;
 };
+
+interface CustomActionMetadata {
+  attribute DOMString id;
+  attribute DOMString label; // Description of the action.
+  attribute FrozenArray<MediaImage> artwork;
+};
+
+dictionary MediaImage {
+  required USVString src;
+  DOMString sizes = "";
+  DOMString type = "";
+};
 ```
 
 ## Example
@@ -79,6 +98,20 @@ interface PictureInPictureWindow {
 <script>
   // Hide button if Picture-in-Picture is not supported or disabled.
   pipButton.hidden = !document.pictureInPictureEnabled || video.disablePictureInPicture;
+
+  const pipControls = [
+    {
+      id: 'thumbs-up',
+      label: 'Thumbs up',
+      icons: [ { src: 'http://dummyimage.com/96x96', sizes: '96x96', type: 'image/png' }, ...]
+    }, {
+      id: 'thumbs-down',
+      label: 'Thumbs down',
+      icons: [ { src: 'http://dummyimage.com/96x96', sizes: '96x96', type: 'image/png' }, ...]
+    }
+  ];
+
+  await video.setPictureInPictureControls(pipControls);
 
   pipButton.addEventListener('click', function() {
     // If there is no element in Picture-in-Picture yet, let's request
@@ -112,6 +145,13 @@ interface PictureInPictureWindow {
 
   video.addEventListener('leavepictureinpicture', function() {
     // Video element left Picture-In-Picture mode.
+  });
+
+  video.addEventListener('pictureinpicturecontrolsclick', event => {
+    switch (event.id) {
+      'thumbs-up': ...
+      'thumbs-down': ...
+    };
   });
 </script>
 ```

--- a/explainer.md
+++ b/explainer.md
@@ -50,7 +50,7 @@ partial interface HTMLVideoElement {
   // On the fullscreen API, they live on the Document.
   attribute EventHandler onenterpictureinpicture;
   attribute EventHandler onleavepictureinpicture;
-  attribute PictureInPictureEventHandler onpictureinpicturecontrolsclick;
+  attribute PictureInPictureControlsEventHandler onpictureinpicturecontrolsclick;
 
   [CEReactions]
   attribute boolean disablePictureInPicture;
@@ -85,7 +85,7 @@ dictionary MediaImage {
   DOMString type = "";
 };
 
-interface PictureInPictureEventHandler : EventHandler {
+interface PictureInPictureControlsEventHandler : EventHandler {
   attribute DOMString id;
 }
 ```

--- a/explainer.md
+++ b/explainer.md
@@ -50,7 +50,7 @@ partial interface HTMLVideoElement {
   // On the fullscreen API, they live on the Document.
   attribute EventHandler onenterpictureinpicture;
   attribute EventHandler onleavepictureinpicture;
-  attribute EventHandler pictureinpicturecontrolsclick;
+  attribute EventHandler onpictureinpicturecontrolsclick;
 
   [CEReactions]
   attribute boolean disablePictureInPicture;

--- a/explainer.md
+++ b/explainer.md
@@ -15,7 +15,6 @@ Many users want to continue consuming media while they interact with other conte
 *   A website wants to inject an action into the Picture-in-Picture window by providing information used for the action in order to give its users control over the PiP’d media.
 *   A website wants to be notified when the user interacts with the action in order to handle it.
 
-
 ### For future considerations or candidates for first API
 
 *   A website wants to be notified when the user initiates Picture-in-Picture from the browser UI in order to decide whether it wants to grant this request.
@@ -46,7 +45,6 @@ The proposed API is very similar to the Fullscreen API as they have similar prop
 ```
 partial interface HTMLVideoElement {
   Promise<PictureInPictureWindow> requestPictureInPicture();
-
   Promise<void> setPictureInPictureControls(FrozenArray<CustomActionMetadata> action);
 
   // On the fullscreen API, they live on the Document.

--- a/explainer.md
+++ b/explainer.md
@@ -45,7 +45,7 @@ The proposed API is very similar to the Fullscreen API as they have similar prop
 ```
 partial interface HTMLVideoElement {
   Promise<PictureInPictureWindow> requestPictureInPicture();
-  Promise<void> setPictureInPictureControls(FrozenArray<CustomActionMetadata> action);
+  Promise<void> setPictureInPictureControls(FrozenArray<PictureInPictureControl> pipControls);
 
   // On the fullscreen API, they live on the Document.
   attribute EventHandler onenterpictureinpicture;
@@ -73,10 +73,10 @@ interface PictureInPictureWindow {
   attribute EventHandler onresize;
 };
 
-interface CustomActionMetadata {
+interface PictureInPictureControl {
   attribute DOMString id;
   attribute DOMString label; // Description of the action.
-  attribute FrozenArray<MediaImage> artwork;
+  attribute FrozenArray<MediaImage> icons;
 };
 
 dictionary MediaImage {

--- a/explainer.md
+++ b/explainer.md
@@ -50,7 +50,7 @@ partial interface HTMLVideoElement {
   // On the fullscreen API, they live on the Document.
   attribute EventHandler onenterpictureinpicture;
   attribute EventHandler onleavepictureinpicture;
-  attribute EventHandler onpictureinpicturecontrolsclick;
+  attribute PictureInPictureEventHandler onpictureinpicturecontrolsclick;
 
   [CEReactions]
   attribute boolean disablePictureInPicture;
@@ -84,6 +84,10 @@ dictionary MediaImage {
   DOMString sizes = "";
   DOMString type = "";
 };
+
+interface PictureInPictureEventHandler : EventHandler {
+  attribute DOMString id;
+}
 ```
 
 ## Example

--- a/implementation-status.md
+++ b/implementation-status.md
@@ -43,3 +43,6 @@ https://dev.windows.com/en-us/microsoft-edge/platform/status/pictureinpicture
 
 # Safari
 https://bugs.webkit.org/show_bug.cgi?id=182688
+
+# Polyfill
+https://github.com/gbentaieb/pip-polyfill/


### PR DESCRIPTION
@beaufortfrancois @mounirlamouri PTAL, thanks! 

This change adds custom actions to the Picture-in-Picture explainer.

Currently, each action is added and handler set individually. Alternatively, we could set all the actions together, including the handlers. How flexible would we want for action properties (e.g. handler functions) to be updated?

Another option could be bubbling an ‘onpictureinpictureaction’ event and setting an id per action, which means there will be no callback handler set explicitly per action.

Note: MediaImage is reused from the Media Session API.