### PR TITLE
Do not pause playback when exiting Picture-in-Picture

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -192,9 +192,9 @@ the user agent MUST run the following steps:
 
 It is NOT RECOMMENDED that video playback state changes when the <a>exit
 Picture-in-Picture algorithm</a> is invoked. The website SHOULD be in control
-of the experience if it's website's initiated. User agent MAY expose
+of the experience if it is website initiated. However, user agent MAY expose
 Picture-in-Picture window controls that change video playback state (e.g.
-pause) though.
+pause).
 
 ## Disable Picture-in-Picture ## {#disable-pip}
 

--- a/index.bs
+++ b/index.bs
@@ -190,6 +190,9 @@ the user agent MUST run the following steps:
     {{leavepictureinpicture}} at the |video| with its {{bubbles}} attribute
     initialized to true.
 
+The user agent SHOULD NOT change video playback state when video leaves
+Picture-in-Picture.
+
 ## Disable Picture-in-Picture ## {#disable-pip}
 
 Some pages may want to disable Picture-in-Picture for a video element. To

--- a/index.bs
+++ b/index.bs
@@ -190,8 +190,11 @@ the user agent MUST run the following steps:
     {{leavepictureinpicture}} at the |video| with its {{bubbles}} attribute
     initialized to true.
 
-The user agent SHOULD NOT change video playback state when video leaves
-Picture-in-Picture.
+It is NOT RECOMMENDED that video playback state changes when the <a>exit
+Picture-in-Picture algorithm</a> is invoked. The website SHOULD be in control
+of the experience if it's website's initiated. User agent MAY expose
+Picture-in-Picture window controls that change video playback state (e.g.
+pause) though.
 
 ## Disable Picture-in-Picture ## {#disable-pip}
 


### PR DESCRIPTION
Following Safari's implementation, video playback MUST not pause when exiting Picture-in-Picture from the API.

@mounirlamouri WDYT of this simple change?


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/picture-in-picture/pull/73.html" title="Last updated on Jun 12, 2018, 5:19 AM GMT (fbd8519)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/picture-in-picture/73/2ed9c31...fbd8519.html" title="Last updated on Jun 12, 2018, 5:19 AM GMT (fbd8519)">Diff</a>