### PR TITLE
Abort requestPictureInPicture steps if video is pictureInPictureElement

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -159,10 +159,11 @@ invoked, the user agent MUST run the following steps:
     |video|, throw a {{InvalidStateError}} and abort these steps.
 6. If the algorithm is not <a>triggered by user activation</a>, throw a
     {{NotAllowedError}} and abort these steps.
-7. Set {{pictureInPictureElement}} to |video|.
-8. Let <dfn>Picture-in-Picture window</dfn> be a new instance of
+7. If |video| is {{pictureInPictureElement}}, abort these steps.
+8. Set {{pictureInPictureElement}} to |video|.
+9. Let <dfn>Picture-in-Picture window</dfn> be a new instance of
     {{PictureInPictureWindow}} associated with {{pictureInPictureElement}}.
-9. <a>Queue a task</a> to <a>fire an event</a> with the name
+10. <a>Queue a task</a> to <a>fire an event</a> with the name
     {{enterpictureinpicture}} at the |video| with its {{bubbles}} attribute
     initialized to true.
 


### PR DESCRIPTION
We should resolve requestPictureInPicture with existing Picture-in-Picture window when video is already pictureInPictureElement.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/picture-in-picture/pull/75.html" title="Last updated on Jun 15, 2018, 7:25 AM GMT (37447bf)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/picture-in-picture/75/77628ce...37447bf.html" title="Last updated on Jun 15, 2018, 7:25 AM GMT (37447bf)">Diff</a>