### PR TITLE
IDL for requestPictureInPicture and exitPictureInPicture should specify that a new object is returned

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -41,7 +41,7 @@ The proposed API is very similar to the Fullscreen API as they have similar prop
 
 ```
 partial interface HTMLVideoElement {
-  Promise<PictureInPictureWindow> requestPictureInPicture();
+  [NewObject] Promise<PictureInPictureWindow> requestPictureInPicture();
 
   // On the fullscreen API, they live on the Document.
   attribute EventHandler onenterpictureinpicture;
@@ -54,7 +54,7 @@ partial interface HTMLVideoElement {
 partial interface Document {
   readonly attribute boolean pictureInPictureEnabled;
 
-  Promise<void> exitPictureInPicture();
+  [NewObject] Promise<void> exitPictureInPicture();
 };
 
 partial interface DocumentOrShadowRoot {

--- a/index.bs
+++ b/index.bs
@@ -254,7 +254,7 @@ in order to notify the website of the Picture-in-Picture status changes.
 
 <pre class="idl">
 partial interface HTMLVideoElement {
-  Promise&lt;PictureInPictureWindow> requestPictureInPicture();
+  [NewObject] Promise&lt;PictureInPictureWindow> requestPictureInPicture();
 
   attribute EventHandler onenterpictureinpicture;
   attribute EventHandler onleavepictureinpicture;
@@ -281,7 +281,7 @@ parallel</a>:
 partial interface Document {
   readonly attribute boolean pictureInPictureEnabled;
 
-  Promise&lt;void> exitPictureInPicture();
+  [NewObject] Promise&lt;void> exitPictureInPicture();
 };
 </pre>
 


### PR DESCRIPTION
Following https://github.com/WICG/media-capabilities/issues/91, we should mark `requestPictureInPicture` and `exitPictureInPicture` as `[NewObject]` as a new object is always returned.