### PR TITLE
PictureInPictureWindow inherits from EventTarget

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -324,7 +324,7 @@ The {{pictureInPictureElement}} attribute's getter must run these steps:
 ## Interface <code>PictureInPictureWindow</code> ## {#interface-picture-in-picture-window}
 
 <pre class="idl">
-interface PictureInPictureWindow {
+interface PictureInPictureWindow : EventTarget {
   readonly attribute long width;
   readonly attribute long height;
 


### PR DESCRIPTION
As noted by @lukebjerring in https://github.com/web-platform-tests/wpt/pull/11916, the interface `PictureInPictureWindow` should inherit from `EventTarget`.

TBR @mounirlamouri 