### PR TITLE
Updated editors metadata

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -8,8 +8,8 @@ Favicon: https://raw.githubusercontent.com/google/material-design-icons/master/a
 Group: WICG
 Repository: wicg/picture-in-picture
 !Web Platform Tests: <a href="https://github.com/web-platform-tests/wpt/tree/master/feature-policy">feature-policy/</a><br/><a href="https://github.com/web-platform-tests/wpt/tree/master/picture-in-picture">picture-in-picture/</a>
-Editor: François Beaufort, Google, fbeaufort@google.com
-Editor: Mounir Lamouri, Google, mlamouri@google.com
+Editor: François Beaufort, w3cid 81174, Google LLC https://www.google.com, fbeaufort@google.com
+Editor: Mounir Lamouri, w3cid 45389, Google LLC https://www.google.com, mlamouri@google.com
 Abstract: This specification intends to provide APIs to allow websites to
 Abstract: create a floating video window always on top of other windows so that
 Abstract: users may continue consuming media while they interact with other


### PR DESCRIPTION
Google, Inc. is now Google LLC. Added editor ID for Francois Beaufort and Mounir Lamouri.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/picture-in-picture/pull/78.html" title="Last updated on Aug 24, 2018, 6:47 AM GMT (2ae5999)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/picture-in-picture/78/4f62711...2ae5999.html" title="Last updated on Aug 24, 2018, 6:47 AM GMT (2ae5999)">Diff</a>