### PR TITLE
Add note for aspect ratio

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -182,7 +182,8 @@ agent MAY transition out of Picture-in-Picture when the video element enters a
 state that is considered not compatible with Picture-in-Picture.
 
 Styles applied to |video| (such as opacity, visibility, transform, etc.) MUST
-NOT apply in the Picture-in-Picture window.
+NOT apply in the Picture-in-Picture window. Its aspect ratio is based on the
+video size.
 
 ## Exit Picture-in-Picture ## {#exit-pip}
 


### PR DESCRIPTION
This simply states that Picture-in-Picture window aspect ratio is based on the video size.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/picture-in-picture/pull/87.html" title="Last updated on Sep 28, 2018, 7:11 AM GMT (73cc97b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/picture-in-picture/87/d11dde2...73cc97b.html" title="Last updated on Sep 28, 2018, 7:11 AM GMT (73cc97b)">Diff</a>