### PR TITLE
Add window size API requirements

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -26,6 +26,7 @@ Many users want to continue consuming media while they interact with other conte
 
 *   The API will notify the website when it enters and leave Picture-in-Picture mode.
 *   The API will allow the website to trigger Picture-in-Picture via a user gesture on a video element.
+*   The API will allow the website to know the size of Picture-in-Picture window and notify the website when it changes.
 *   The API will allow the website to exit Picture-in-Picture.
 *   The API will allow the website to check if Picture-in-Picture can be triggered.
 

--- a/index.bs
+++ b/index.bs
@@ -60,6 +60,8 @@ by exposing the following sets of properties to the API:
 * Notify the website when it enters and leave Picture-in-Picture mode.
 * Allow the website to trigger Picture-in-Picture via a user gesture on a video
     element.
+* Allow the website to know the size of Picture-in-Picture window and notify
+    the website when it changes.
 * Allow the website to exit Picture-in-Picture.
 * Allow the website to check if Picture-in-Picture can be triggered.
 


### PR DESCRIPTION
This adds a bullet point in API requirements regarding the size of the Picture-in-Picture window.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/picture-in-picture/pull/88.html" title="Last updated on Sep 28, 2018, 7:42 AM GMT (2734bdb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/picture-in-picture/88/d11dde2...2734bdb.html" title="Last updated on Sep 28, 2018, 7:42 AM GMT (2734bdb)">Diff</a>