### PR TITLE
Be more explicit about PiP window visibility

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -54,7 +54,8 @@ spec:html; type:attribute; for:HTMLMediaElement; text:readyState
 Many users want to continue consuming media while they interact with other
 content, sites, or applications on their device. A common UI affordance for
 this type of activity is Picture-in-Picture (PiP), where the video is contained
-in a separate miniature window that is always on top of other windows.
+in a separate miniature window that is always on top of other windows. This
+window stays visible even when user agent is not visible.
 Picture-in-Picture is a common platform-level feature among desktop and mobile
 OSs.
 
@@ -267,11 +268,14 @@ available controls on the Picture-in-Picture window.
 
 ## Interaction with Page Visibility ## {#page-visibility}
 
+When {{pictureInPictureElement}} is set, the Picture-in-Picture window MUST
+be visible, even when <a>Document</a> is not in focus or hidden.
+
 The [[Page-Visibility]] specification defines a {{Document/visibilityState}}
-attribute used to determine the visibility state of a top level browsing
-context. For the purpose of Picture-in-Picture, the {{Document/visibilityState}}
-MUST always return "visible" when {{pictureInPictureElement}}
-is set and the Picture-in-Picture window is visible.
+attribute used to determine the visibility state of a <a>top-level browsing
+context</a>. For the purpose of Picture-in-Picture, the
+{{Document/visibilityState}} MUST always return "visible" when
+{{pictureInPictureElement}} is set.
 
 ## One Picture-in-Picture window ## {#one-pip-window}
 

--- a/index.bs
+++ b/index.bs
@@ -269,7 +269,8 @@ available controls on the Picture-in-Picture window.
 ## Interaction with Page Visibility ## {#page-visibility}
 
 When {{pictureInPictureElement}} is set, the Picture-in-Picture window MUST
-be visible, even when <a>Document</a> is not in focus or hidden.
+be visible, even when <a>Document</a> is not in focus or hidden. The user agent
+SHOULD provide a way for users to manually close the Picture-in-Picture window.
 
 The [[Page-Visibility]] specification defines a {{Document/visibilityState}}
 attribute used to determine the visibility state of a <a>top-level browsing


### PR DESCRIPTION
@yoavweiss noted that spec doesn't tell much about the obvious visibility state of the Picture-in-Picture window. This PR fixes this.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/picture-in-picture/pull/102.html" title="Last updated on Nov 26, 2018, 11:36 AM GMT (da07e5e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/picture-in-picture/102/ed25bd1...da07e5e.html" title="Last updated on Nov 26, 2018, 11:36 AM GMT (da07e5e)">Diff</a>