### PR TITLE
Add use cases for disablePictureInPicture

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -232,9 +232,11 @@ pause).
 
 ## Disable Picture-in-Picture ## {#disable-pip}
 
-Some pages may want to disable Picture-in-Picture for a video element. To
-support this, a new {{disablePictureInPicture}} attribute is added to the list
-of content attributes for video elements.
+Some pages may want to disable Picture-in-Picture for a video element; for
+example, they may want to prevent user agent to suggest a Picture-in-Picture
+context menu or to request Picture-in-Picture automatically in some cases.
+To support these use cases, a new {{disablePictureInPicture}} attribute is
+added to the list of content attributes for video elements.
 
 A corresponding {{disablePictureInPicture}} IDL attribute which reflects the
 value of element’s {{disablePictureInPicture}} content attribute is added to


### PR DESCRIPTION
@yoavweiss suggested adding some use cases for why we need `disablePictureInPicture`.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/picture-in-picture/pull/103.html" title="Last updated on Nov 26, 2018, 11:44 AM GMT (652607b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/picture-in-picture/103/ed25bd1...652607b.html" title="Last updated on Nov 26, 2018, 11:44 AM GMT (652607b)">Diff</a>