### PR TITLE
Exit pip on document unload

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -230,6 +230,9 @@ of the experience if it is website initiated. However, user agent MAY expose
 Picture-in-Picture window controls that change video playback state (e.g.
 pause).
 
+As one of the <a>unloading document cleanup steps</a>, run the <a>exit
+Picture-in-Picture algorithm</a>.
+
 ## Disable Picture-in-Picture ## {#disable-pip}
 
 Some pages may want to disable Picture-in-Picture for a video element. To


### PR DESCRIPTION
It wasn't clear to @yoavweiss that the exit pip algorithm was run on document unload. This PR addresses this.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/picture-in-picture/pull/106.html" title="Last updated on Nov 26, 2018, 12:30 PM GMT (08960b9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/picture-in-picture/106/ed25bd1...08960b9.html" title="Last updated on Nov 26, 2018, 12:30 PM GMT (08960b9)">Diff</a>