### PR TITLE
Remove autoplay

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -151,8 +151,9 @@ Even though the API only applies on `HTMLVideoElement` at the moment, there is o
   canvas.getContext('2d').fillRect(0, 0, canvas.width, canvas.height);
 
   const video = document.createElement('video');
-  video.autoplay = true;
+  video.muted = true;
   video.srcObject = canvas.captureStream(60 /* fps */);
+  video.play();
 
   pipButton.addEventListener('click', function() {
     video.requestPictureInPicture();


### PR DESCRIPTION
According to https://chromium-review.googlesource.com/c/chromium/src/+/1353928, autoplay doesn't work on muted video that are not visible. This PR makes sure we document `play()` instead.