### PR TITLE
Don't require user gesture when capturing user media

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -38,6 +38,8 @@ spec: Remote-Playback; urlPrefix: https://w3c.github.io/remote-playback/#dfn-
         text: local playback state
 spec: Page-Visibility; urlPrefix: https://www.w3.org/TR/page-visibility/
     type: attribute; text: visibilityState; for: Document; url: dom-visibilitystate
+spec: Media Capture and Streams; urlPrefix: https://www.w3.org/TR/mediacapture-streams/
+    type: attribute; text: getUserMedia(); url:dom-mediadevices-getusermedia()
 </pre>
 
 <pre class="link-defaults">
@@ -182,7 +184,8 @@ invoked, the user agent MUST run the following steps:
     these steps.
 5. OPTIONALLY, if the {{disablePictureInPicture}} attribute is present on
     |video|, throw a {{InvalidStateError}} and abort these steps.
-6. If the algorithm is not <a>triggered by user activation</a>, throw a
+6. If document is NOT capturing any user media with {{getUserMedia()}} and
+    the algorithm is not <a>triggered by user activation</a>, throw a
     {{NotAllowedError}} and abort these steps.
 7. If |video| is {{pictureInPictureElement}}, abort these steps.
 8. Set {{pictureInPictureElement}} to |video|.


### PR DESCRIPTION
Video meetings web apps would benefit from automatic Picture-in-Picture behavior when user switches back and forth between web app and other applications/tabs. This is currently not possible with the user gesture requirement in https://wicg.github.io/picture-in-picture/#request-pip (step 6).

I'm proposing to not enforce the user gesture requirement if document is capturing user media with `getUserMedia()` when requesting Picture-in-Picture.

What do you think @mounirlamouri?

```js
const video = document.createElement('video');
video.srcObject = await navigator.mediaDevices.getUserMedia({ video: true });

window.onblur = _ => { video.requestPictureInPicture(); }
window.onfocus = _ => { document.exitPictureInPicture(); }
```


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/picture-in-picture/pull/109.html" title="Last updated on Dec 6, 2018, 7:35 PM GMT (b76b1dd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/picture-in-picture/109/658c859...b76b1dd.html" title="Last updated on Dec 6, 2018, 7:35 PM GMT (b76b1dd)">Diff</a>