### PR TITLE
Treat DocumentOrShadowRoot as an interface mixin

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -355,7 +355,7 @@ parallel</a>:
 ## Extension to <code>DocumentOrShadowRoot</code> ## {#documentorshadowroot-extension}
 
 <xmp class="idl">
-partial interface DocumentOrShadowRoot {
+partial interface mixin DocumentOrShadowRoot {
   readonly attribute Element? pictureInPictureElement;
 };
 </xmp>


### PR DESCRIPTION
Matching https://dom.spec.whatwg.org/#mixin-documentorshadowroot.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/foolip/picture-in-picture/pull/114.html" title="Last updated on Jan 21, 2019, 2:07 PM UTC (03da806)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/picture-in-picture/114/658c859...foolip:03da806.html" title="Last updated on Jan 21, 2019, 2:07 PM UTC (03da806)">Diff</a>