### PR TITLE
Do not require user gesture if pictureInPictureElement is set

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -358,7 +358,8 @@ return <a>a new promise</a> |promise| and run the following steps <a>in
 parallel</a>:
 
 1. Let |video| be the video element on which the method was invoked.
-2. Let |userActivationRequired| be `true`.
+2. Let |userActivationRequired| be `true` if {{pictureInPictureElement}} is
+    null. It is `false` otherwise.
 3. Let |playingRequired| be `false`.
 4. Run the <a>request Picture-in-Picture algorithm</a> with |video|,
     |userActivationRequired|, and |playingRequired|.


### PR DESCRIPTION
FIX #116


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/picture-in-picture/pull/117.html" title="Last updated on Feb 6, 2019, 7:54 AM UTC (d4858cd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/picture-in-picture/117/ab2cfb7...d4858cd.html" title="Last updated on Feb 6, 2019, 7:54 AM UTC (d4858cd)">Diff</a>