### PR TITLE
Add `:picture-in-picture` CSS pseudo-class

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -472,6 +472,14 @@ dictionary EnterPictureInPictureEventInit : EventInit {
 The <a>task source</a> for all the tasks queued in this specification is the
 <a>media element event task source</a> of the video element in question.
 
+## CSS pseudo-class ## {#css-pseudo-class}
+
+The `:picture-in-picture` <a>pseudo-class</a> MUST match any <a>element</a>
+|element| for which one of the following conditions is true:
+- |element| is {{pictureInPictureElement}}.
+- |element| is a <a>shadow host</a> and the result of <a>retargeting</a> its
+   <a>node document</a>’s {{pictureInPictureElement}} against |element| is |element|.
+
 # Security considerations # {#security-considerations}
 
 <em>This section is non-normative.</em>


### PR DESCRIPTION
I'd like to add a `:picture-in-picture` CSS pseudo-class (like Fullscreen API [has](https://fullscreen.spec.whatwg.org/#:fullscreen-pseudo-class)) to help web developers to customize their video player when video enters and leave Picture-in-Picture.

I hope that a simple CSS pseudo-class would help.

What do you think @jernoble, @scottlow, and @mounirlamouri?


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/picture-in-picture/pull/120.html" title="Last updated on Mar 11, 2019, 11:36 AM UTC (bd2c1c7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/picture-in-picture/120/ab2cfb7...bd2c1c7.html" title="Last updated on Mar 11, 2019, 11:36 AM UTC (bd2c1c7)">Diff</a>