### PR TITLE
Enable CI for v2 branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ script: bash ./deploy.sh
 branches:
   only:
     - master
+    - v2
 
 env:
   global:

--- a/deploy.sh
+++ b/deploy.sh
@@ -24,7 +24,7 @@ git checkout $TARGET_BRANCH || git checkout --orphan $TARGET_BRANCH
 cd ..
 
 # Clean out existing contents
-rm -rf out/* || exit 0
+rm -rf out/*.html || exit 0
 
 # Build the html output
 make && mv index.html out/index.html


### PR DESCRIPTION
This enables Travis CI on the v2 branch. To be picked up by travis this update needs to be on both the master and v2 branch.

I will add another PR to change the deploy.sh script on the v2 branch to save the generated html to out/v2/index.html (so the URL would be https://wicg.github.io/picture-in-picture/v2/). This is why there is also a change to deploy.sh on master to only clear html files.