### PR TITLE
Remove retargeting for CSS pseudo class

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -484,11 +484,9 @@ The <a>task source</a> for all the tasks queued in this specification is the
 
 ## CSS pseudo-class ## {#css-pseudo-class}
 
-The `:picture-in-picture` <a>pseudo-class</a> MUST match any <a>element</a>
-|element| for which one of the following conditions is true:
-- |element| is {{pictureInPictureElement}}.
-- |element| is a <a>shadow host</a> and the result of <a>retargeting</a> its
-    <a>node document</a>’s {{pictureInPictureElement}} against |element| is |element|.
+The `:picture-in-picture` <a>pseudo-class</a> MUST match the Picture-in-Picture
+element. It is different from the {{pictureInPictureElement}} as it does NOT
+apply to the shadow host chain.
 
 # Security considerations # {#security-considerations}
 


### PR DESCRIPTION
Following discussions at https://groups.google.com/a/chromium.org/d/msg/blink-dev/X-qPSmdSR_g/mRKxdlVICgAJ and https://github.com/w3c/webcomponents/issues/804, this PR removes retargeting for the `:picture-in-picture` CSS pseudo class that was added at https://github.com/WICG/picture-in-picture/pull/120