### PR TITLE
Fix event fired steps

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -201,9 +201,10 @@ run the following steps:
 10. Let <dfn>Picture-in-Picture window</dfn> be a new instance of
     {{PictureInPictureWindow}} associated with {{pictureInPictureElement}}.
 11. <a>Queue a task</a> to <a>fire an event</a> with the name
-    {{enterpictureinpicture}} at the |video| with its {{bubbles}} attribute
-    initialized to `true` and its {{pictureInPictureWindow}} attribute
-    initialized to <a>Picture-in-Picture window</a>.
+    {{enterpictureinpicture}} using {{EnterPictureInPictureEvent}} at the
+    |video| with its {{bubbles}} attribute initialized to `true` and its
+    {{pictureInPictureWindow}} attribute initialized to
+    <a>Picture-in-Picture window</a>.
 
 It is RECOMMENDED that video frames are not rendered in the page and in the
 Picture-in-Picture window at the same time but if they are, they MUST be kept
@@ -455,8 +456,7 @@ When the size of the <a>Picture-in-Picture window</a> associated with
 ## Event types ## {#event-types}
 
 : <dfn event for="HTMLVideoElement">`enterpictureinpicture`</dfn>
-:: Fired on a {{HTMLVideoElement}} when it enters Picture-in-Picture. It uses
-    the {{EnterPictureInPictureEvent}} interface.
+:: Fired on a {{HTMLVideoElement}} when it enters Picture-in-Picture.
 
 <xmp class="idl">
 [


### PR DESCRIPTION
This PR rewords how event steps are fired according to #146.

FYI @marcoscaceres 
FIX #146


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/picture-in-picture/pull/147.html" title="Last updated on Jun 3, 2019, 8:23 AM UTC (babd759)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/picture-in-picture/147/f8dae9f...babd759.html" title="Last updated on Jun 3, 2019, 8:23 AM UTC (babd759)">Diff</a>